### PR TITLE
feat: Add web search capability to PersonalBot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _deploy/
 cache/
 templates_c/
 vendor/
+configs/search_api.json

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -36,9 +36,49 @@ The core of the task involved modifying the `PersonalBot` class to:
     *   Added tests for `getAnswer` (mocking GPT for decision and final response, verifying context passed to GPT).
     *   Used `$this->at()` to specify sequences of mocked GPT calls within `getAnswer` tests.
 
+## Web Search API Integration Details
+
+To provide real web search capabilities, the bot now integrates with the **Google Custom Search API**.
+
+### API Used
+- **Google Custom Search API**: This API allows you to create a custom search engine that can be tailored to search specific websites or the entire web. It provides structured search results in JSON format.
+
+### Setup and Configuration
+
+1.  **Obtain a Google API Key**:
+    - Go to the [Google Cloud Console](https://console.cloud.google.com/).
+    - Create a new project or select an existing one.
+    - Enable the "Custom Search API" for your project (usually found under "APIs & Services" > "Library").
+    - Create credentials for the API: Go to "APIs & Services" > "Credentials" and create an "API key".
+    - **Important**: Restrict your API key to only allow access to the "Custom Search API" for security.
+
+2.  **Create a Custom Search Engine ID (CX ID)**:
+    - Go to the [Custom Search Engine control panel](https://programmablesearch.google.com/controlpanel/all).
+    - Create a new search engine.
+    - Configure it to search the entire web or specific sites as needed. For general information, select "Search the entire web".
+    - Once created, find your "Search engine ID" (this is your CX ID) in the setup overview.
+
+3.  **Configure the Application**:
+    - In the `configs/` directory of this project, you'll find a sample file `search_api.json.sample`.
+    - Create a copy of this file named `search_api.json`.
+    - Edit `search_api.json` and replace the placeholder values with your actual Google API Key and CX ID:
+      ```json
+      {
+          "google_custom_search_api_key": "YOUR_ACTUAL_GOOGLE_API_KEY",
+          "google_custom_search_cx_id": "YOUR_ACTUAL_CX_ID"
+      }
+      ```
+    - The `configs/search_api.json` file is included in `.gitignore`, so your credentials will not be committed to the repository.
+
+### Implementation Notes
+- The `WebSearchTool::search()` method now uses the `google/apiclient` library to communicate with the Google Custom Search API.
+- API key and CX ID are loaded by `PersonalBot` from `configs/search_api.json` and passed to `WebSearchTool`.
+- The tool fetches a few top results and extracts their titles and snippets to form a summary for the bot's context.
+- Basic error handling is in place for API communication issues or missing configuration.
+
 ## Future Considerations
 
-*   **Real Web Search API Integration**: The `WebSearchTool::search()` is currently a placeholder. Integrating a real search API (e.g., Google Search API, Bing Search API, or a library like SerpAPI) would be the next step for full functionality. This would also involve API key management and potentially error handling for network issues or API limits.
+*   **Advanced Web Search API Usage**: While basic Google Custom Search API integration is complete, future work could involve more robust error handling, exploring other search APIs, or using more advanced features of the current API (e.g., filtering, sorting, pagination if more results are needed).
 *   **Refining Search Queries**: The user's message is directly used as a search query. NLP techniques could be applied to extract better search terms from the message.
 *   **Summarizing Search Results**: Real search results can be verbose. A summarization step (possibly another GPT call or a different model) might be needed to make the information concise for the bot's context.
 *   **Caching**: For identical or similar queries, caching search results could optimize performance and reduce API calls.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -1,0 +1,44 @@
+# Learnings from Implementing Web Search Feature
+
+This document outlines the key learnings and observations from the task of integrating a web search capability into the existing PHP-based chatbot.
+
+## Key Implementation Steps
+
+The core of the task involved modifying the `PersonalBot` class to:
+1.  **Decide if a web search is necessary**: A GPT prompt (`PROMPT_JUDGE_WEB_SEARCH`) was introduced to make this decision based on the user's message.
+2.  **Perform the web search**: A new `WebSearchTool` class (currently with a placeholder implementation) was created to handle the actual search query.
+3.  **Integrate search results into context**: The bot's GPT context (`GPT_CONTEXT`) was augmented to include a section for web search results, which are then populated if a search is performed.
+4.  **Orchestrate the flow**: The `PersonalBot::getAnswer` method was updated to manage this new workflow: decide -> search (if needed) -> augment context -> generate answer.
+
+## Challenges and Solutions
+
+*   **Mocking Dependencies for Testing**:
+    *   **Challenge**: `PersonalBot` relies on the `Gpt` class. Testing methods like `__shouldPerformWebSearch` and `getAnswer` required controlling the output of `Gpt` calls.
+    *   **Solution**: PHPUnit's mocking capabilities (`createMock`, `method`, `willReturn`, `at`) were used. A helper method `setPrivateProperty` (added to `PersonalBotTest`) was necessary to inject the mocked `Gpt` instance into the `PersonalBot` instance under test, as the `$gpt` property was private and not set via the constructor in a way that allowed easy test-time replacement.
+
+*   **Testing Private Methods**:
+    *   **Challenge**: Some logic (like decision-making for search, context assembly) was encapsulated in private methods (`__shouldPerformWebSearch`, `__getContext`).
+    *   **Solution**: The existing test utility `yananob\MyTools\Test::invokePrivateMethod` was leveraged to directly test these private methods, allowing for more focused unit tests.
+
+*   **Context Management**:
+    *   **Challenge**: Ensuring the GPT prompt context was correctly and dynamically assembled with optional sections (like web search results, user characteristics, conversation history) without errors.
+    *   **Solution**: A placeholder system in the `GPT_CONTEXT` string (e.g., `<web_search_results>`) combined with `str_replace` and a helper method `__removeFromContext` for conditional removal of sections proved effective.
+
+*   **Static vs. Instance Methods for Tools**:
+    *   **Consideration**: `WebSearchTool::search()` was implemented as a static method. While simple for a placeholder, if it involved more complex dependencies or state, an instance method and dependency injection for `WebSearchTool` itself might have been preferable for easier mocking. For the current scope, direct static call was acceptable. The `PersonalBot` uses a fully qualified name `\MyApp\WebSearchTool::search()` which is clear.
+
+## Unit Testing Highlights
+
+*   Created `WebSearchToolTest.php` for the new tool.
+*   Significantly updated `PersonalBotTest.php`:
+    *   Added tests for `__shouldPerformWebSearch` (mocking GPT for decision).
+    *   Added tests for `__getContext` (verifying inclusion/exclusion of search results).
+    *   Added tests for `getAnswer` (mocking GPT for decision and final response, verifying context passed to GPT).
+    *   Used `$this->at()` to specify sequences of mocked GPT calls within `getAnswer` tests.
+
+## Future Considerations
+
+*   **Real Web Search API Integration**: The `WebSearchTool::search()` is currently a placeholder. Integrating a real search API (e.g., Google Search API, Bing Search API, or a library like SerpAPI) would be the next step for full functionality. This would also involve API key management and potentially error handling for network issues or API limits.
+*   **Refining Search Queries**: The user's message is directly used as a search query. NLP techniques could be applied to extract better search terms from the message.
+*   **Summarizing Search Results**: Real search results can be verbose. A summarization step (possibly another GPT call or a different model) might be needed to make the information concise for the bot's context.
+*   **Caching**: For identical or similar queries, caching search results could optimize performance and reduce API calls.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "yananob/my-tools": "dev-main",
         "yananob/my-gcp-tools": "dev-main",
         "nesbot/carbon": "^3.8",
-        "google/apiclient": "^2.15"
+        "google/apiclient": "^2.18",
+        "google/apiclient-services": "^0.396.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.3",

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         "yananob/my-tools": "dev-main",
         "yananob/my-gcp-tools": "dev-main",
         "nesbot/carbon": "^3.8",
-        "google/apiclient": "^2.18",
-        "google/apiclient-services": "^0.396.0"
+        "google/apiclient": "^2.15"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.3",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "google/cloud-firestore": "^1.47",
         "yananob/my-tools": "dev-main",
         "yananob/my-gcp-tools": "dev-main",
-        "nesbot/carbon": "^3.8"
+        "nesbot/carbon": "^3.8",
+        "google/apiclient": "^2.15"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03d47b867af1db32d764d60c5fae152b",
+    "content-hash": "1abea3e6c2ec9c662ade79084ad9242d",
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.12.3",
+            "version": "0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba"
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/866551da34e9a618e64a819ee1e01c20d8a588ba",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba",
+                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
+                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
                 "phpunit/phpunit": "^10.1",
-                "vimeo/psalm": "6.8.8"
+                "vimeo/psalm": "5.16.0"
             },
             "type": "library",
             "autoload": {
@@ -56,7 +56,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.12.3"
+                "source": "https://github.com/brick/math/tree/0.12.1"
             },
             "funding": [
                 {
@@ -64,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-28T13:11:00+00:00"
+            "time": "2023-11-29T23:19:16+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -137,16 +137,16 @@
         },
         {
             "name": "cloudevents/sdk-php",
-            "version": "v1.2.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cloudevents/sdk-php.git",
-                "reference": "2d2f14720c83e4ef2b8e17250817b25d59ba055b"
+                "reference": "45c5e1b5c4734bbba2e23ae41d06e7902d35087b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cloudevents/sdk-php/zipball/2d2f14720c83e4ef2b8e17250817b25d59ba055b",
-                "reference": "2d2f14720c83e4ef2b8e17250817b25d59ba055b",
+                "url": "https://api.github.com/repos/cloudevents/sdk-php/zipball/45c5e1b5c4734bbba2e23ae41d06e7902d35087b",
+                "reference": "45c5e1b5c4734bbba2e23ae41d06e7902d35087b",
                 "shasum": ""
             },
             "require": {
@@ -159,7 +159,7 @@
                 "guzzlehttp/psr7": "^2.4.3",
                 "php-http/discovery": "^1.15.2",
                 "phpunit/phpunit": "^9.6.3 || ^10.0.12",
-                "psalm/phar": "5.26.1",
+                "psalm/phar": "5.7.6",
                 "psr/http-factory": "^1.0.1",
                 "psr/http-message": "^1.0.1",
                 "squizlabs/php_codesniffer": "3.7.2"
@@ -174,7 +174,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.2-dev"
+                    "dev-main": "1.1-dev"
                 }
             },
             "autoload": {
@@ -191,20 +191,20 @@
                 "issues": "https://github.com/cloudevents/sdk-php/issues",
                 "source": "https://github.com/cloudevents/sdk-php"
             },
-            "time": "2025-02-07T18:31:27+00:00"
+            "time": "2023-12-18T02:56:02+00:00"
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.1",
+            "version": "v6.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+                "reference": "30c19ed0f3264cb660ea496895cfb6ef7ee3653b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
-                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/30c19ed0f3264cb660ea496895cfb6ef7ee3653b",
+                "reference": "30c19ed0f3264cb660ea496895cfb6ef7ee3653b",
                 "shasum": ""
             },
             "require": {
@@ -252,22 +252,22 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.10.2"
             },
-            "time": "2025-04-09T20:32:01+00:00"
+            "time": "2024-11-24T11:22:49+00:00"
         },
         {
             "name": "google/apiclient",
-            "version": "v2.18.3",
+            "version": "v2.18.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "4eee42d201eff054428a4836ec132944d271f051"
+                "reference": "d8d201ba8a189a3cd7fb34e4da569f2ed440eee7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/4eee42d201eff054428a4836ec132944d271f051",
-                "reference": "4eee42d201eff054428a4836ec132944d271f051",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/d8d201ba8a189a3cd7fb34e4da569f2ed440eee7",
+                "reference": "d8d201ba8a189a3cd7fb34e4da569f2ed440eee7",
                 "shasum": ""
             },
             "require": {
@@ -321,22 +321,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client/issues",
-                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.18.3"
+                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.18.2"
             },
-            "time": "2025-04-08T21:59:36+00:00"
+            "time": "2024-12-16T22:52:40+00:00"
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.396.0",
+            "version": "v0.389.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "ceb2e432e4326c6775d24f62d554395a1a9ad3dd"
+                "reference": "6274e67ee52b1a416ccee0a4eaf337d1139cdaf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/ceb2e432e4326c6775d24f62d554395a1a9ad3dd",
-                "reference": "ceb2e432e4326c6775d24f62d554395a1a9ad3dd",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/6274e67ee52b1a416ccee0a4eaf337d1139cdaf8",
+                "reference": "6274e67ee52b1a416ccee0a4eaf337d1139cdaf8",
                 "shasum": ""
             },
             "require": {
@@ -365,22 +365,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.396.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.389.0"
             },
-            "time": "2025-02-24T01:10:27+00:00"
+            "time": "2025-01-05T01:04:21+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.47.0",
+            "version": "v1.45.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "d6389aae7c009daceaa8da9b7942d8df6969f6d9"
+                "reference": "cfcb93162341ed5022fa976e621f0fa2b05ba6ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/d6389aae7c009daceaa8da9b7942d8df6969f6d9",
-                "reference": "d6389aae7c009daceaa8da9b7942d8df6969f6d9",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/cfcb93162341ed5022fa976e621f0fa2b05ba6ad",
+                "reference": "cfcb93162341ed5022fa976e621f0fa2b05ba6ad",
                 "shasum": ""
             },
             "require": {
@@ -417,43 +417,43 @@
                 "Apache-2.0"
             ],
             "description": "Google Auth Library for PHP",
-            "homepage": "https://github.com/google/google-auth-library-php",
+            "homepage": "http://github.com/google/google-auth-library-php",
             "keywords": [
                 "Authentication",
                 "google",
                 "oauth2"
             ],
             "support": {
-                "docs": "https://cloud.google.com/php/docs/reference/auth/latest",
+                "docs": "https://googleapis.github.io/google-auth-library-php/main/",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.47.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.45.0"
             },
-            "time": "2025-04-15T21:47:20+00:00"
+            "time": "2024-12-11T02:10:48+00:00"
         },
         {
             "name": "google/cloud-core",
-            "version": "v1.62.3",
+            "version": "v1.61.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-cloud-php-core.git",
-                "reference": "0c19d76e7f3b6810c4f2cc1330c693af2681c601"
+                "reference": "c2cd6aff17704dd5a59e2c1c802509f9e82d36fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/0c19d76e7f3b6810c4f2cc1330c693af2681c601",
-                "reference": "0c19d76e7f3b6810c4f2cc1330c693af2681c601",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/c2cd6aff17704dd5a59e2c1c802509f9e82d36fd",
+                "reference": "c2cd6aff17704dd5a59e2c1c802509f9e82d36fd",
                 "shasum": ""
             },
             "require": {
                 "google/auth": "^1.34",
                 "google/gax": "^1.36.0",
-                "guzzlehttp/guzzle": "^6.5.8||^7.4.4",
+                "guzzlehttp/guzzle": "^6.5.8|^7.4.4",
                 "guzzlehttp/promises": "^1.4||^2.0",
                 "guzzlehttp/psr7": "^2.6",
-                "monolog/monolog": "^2.9||^3.0",
+                "monolog/monolog": "^2.9|^3.0",
                 "php": "^8.0",
-                "psr/http-message": "^1.0||^2.0",
-                "rize/uri-template": "~0.3||~0.4"
+                "psr/http-message": "^1.0|^2.0",
+                "rize/uri-template": "~0.3"
             },
             "require-dev": {
                 "erusev/parsedown": "^1.6",
@@ -492,22 +492,22 @@
             ],
             "description": "Google Cloud PHP shared dependency, providing functionality useful to all components.",
             "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.62.3"
+                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.61.0"
             },
-            "time": "2025-05-20T19:49:54+00:00"
+            "time": "2025-01-11T02:14:50+00:00"
         },
         {
             "name": "google/cloud-firestore",
-            "version": "v1.50.0",
+            "version": "v1.47.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-cloud-php-firestore.git",
-                "reference": "22d883035f77dce56936cc1909159b8858bcb0b6"
+                "reference": "a7a2e065dc6c6ccc87fec3a96b4bcbb5e49fb662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-firestore/zipball/22d883035f77dce56936cc1909159b8858bcb0b6",
-                "reference": "22d883035f77dce56936cc1909159b8858bcb0b6",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-firestore/zipball/a7a2e065dc6c6ccc87fec3a96b4bcbb5e49fb662",
+                "reference": "a7a2e065dc6c6ccc87fec3a96b4bcbb5e49fb662",
                 "shasum": ""
             },
             "require": {
@@ -549,9 +549,9 @@
             ],
             "description": "Cloud Firestore Client for PHP",
             "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-firestore/tree/v1.50.0"
+                "source": "https://github.com/googleapis/google-cloud-php-firestore/tree/v1.47.3"
             },
-            "time": "2025-04-18T20:49:28+00:00"
+            "time": "2025-01-11T02:14:50+00:00"
         },
         {
             "name": "google/cloud-functions-framework",
@@ -602,16 +602,16 @@
         },
         {
             "name": "google/common-protos",
-            "version": "4.12.1",
+            "version": "4.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/common-protos-php.git",
-                "reference": "70c4eb1abab5484a23c17a43b0d455259f5d8c1b"
+                "reference": "a2d1a583819286db5ef9403c6a2bfa29c9636c46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/70c4eb1abab5484a23c17a43b0d455259f5d8c1b",
-                "reference": "70c4eb1abab5484a23c17a43b0d455259f5d8c1b",
+                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/a2d1a583819286db5ef9403c6a2bfa29c9636c46",
+                "reference": "a2d1a583819286db5ef9403c6a2bfa29c9636c46",
                 "shasum": ""
             },
             "require": {
@@ -655,22 +655,22 @@
                 "google"
             ],
             "support": {
-                "source": "https://github.com/googleapis/common-protos-php/tree/v4.12.1"
+                "source": "https://github.com/googleapis/common-protos-php/tree/v4.9.0"
             },
-            "time": "2025-05-20T19:49:54+00:00"
+            "time": "2025-01-11T02:14:50+00:00"
         },
         {
             "name": "google/gax",
-            "version": "v1.36.1",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/gax-php.git",
-                "reference": "afdac3bc38a3b17d70668115d7b1a97289ac4d72"
+                "reference": "140599cf5eae2432363ce6198e9fdff851625a7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/afdac3bc38a3b17d70668115d7b1a97289ac4d72",
-                "reference": "afdac3bc38a3b17d70668115d7b1a97289ac4d72",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/140599cf5eae2432363ce6198e9fdff851625a7a",
+                "reference": "140599cf5eae2432363ce6198e9fdff851625a7a",
                 "shasum": ""
             },
             "require": {
@@ -712,22 +712,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/gax-php/issues",
-                "source": "https://github.com/googleapis/gax-php/tree/v1.36.1"
+                "source": "https://github.com/googleapis/gax-php/tree/v1.36.0"
             },
-            "time": "2025-05-20T19:50:43+00:00"
+            "time": "2024-12-11T02:47:43+00:00"
         },
         {
             "name": "google/grpc-gcp",
-            "version": "v0.4.1",
+            "version": "v0.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GoogleCloudPlatform/grpc-gcp-php.git",
-                "reference": "e585b7721bbe806ef45b5c52ae43dfc2bff89968"
+                "reference": "2a80dbf690922aa52bb6bb79b9a32a9637a5c2d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/e585b7721bbe806ef45b5c52ae43dfc2bff89968",
-                "reference": "e585b7721bbe806ef45b5c52ae43dfc2bff89968",
+                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/2a80dbf690922aa52bb6bb79b9a32a9637a5c2d9",
+                "reference": "2a80dbf690922aa52bb6bb79b9a32a9637a5c2d9",
                 "shasum": ""
             },
             "require": {
@@ -757,22 +757,22 @@
             "description": "gRPC GCP library for channel management",
             "support": {
                 "issues": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/issues",
-                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.4.1"
+                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.4.0"
             },
-            "time": "2025-02-19T21:53:22+00:00"
+            "time": "2024-04-03T16:37:55+00:00"
         },
         {
             "name": "google/longrunning",
-            "version": "0.4.7",
+            "version": "0.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/php-longrunning.git",
-                "reference": "624cabb874c10e5ddc9034c999f724894b70a3d3"
+                "reference": "4eb04d47bba8095d5a47f75334b9204c2a4a7ac6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/php-longrunning/zipball/624cabb874c10e5ddc9034c999f724894b70a3d3",
-                "reference": "624cabb874c10e5ddc9034c999f724894b70a3d3",
+                "url": "https://api.github.com/repos/googleapis/php-longrunning/zipball/4eb04d47bba8095d5a47f75334b9204c2a4a7ac6",
+                "reference": "4eb04d47bba8095d5a47f75334b9204c2a4a7ac6",
                 "shasum": ""
             },
             "require-dev": {
@@ -801,22 +801,22 @@
             ],
             "description": "Google LongRunning Client for PHP",
             "support": {
-                "source": "https://github.com/googleapis/php-longrunning/tree/v0.4.7"
+                "source": "https://github.com/googleapis/php-longrunning/tree/v0.4.6"
             },
-            "time": "2025-01-24T21:24:06+00:00"
+            "time": "2024-12-12T21:15:35+00:00"
         },
         {
             "name": "google/protobuf",
-            "version": "v3.25.7",
+            "version": "v3.25.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "6901ac6aed67882732a47d877d4dbd6189cbdcf2"
+                "reference": "dd2cf3f7b577dced3851c2ea76c3daa9f8aa0ff4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/6901ac6aed67882732a47d877d4dbd6189cbdcf2",
-                "reference": "6901ac6aed67882732a47d877d4dbd6189cbdcf2",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/dd2cf3f7b577dced3851c2ea76c3daa9f8aa0ff4",
+                "reference": "dd2cf3f7b577dced3851c2ea76c3daa9f8aa0ff4",
                 "shasum": ""
             },
             "require": {
@@ -845,9 +845,9 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.25.7"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.25.5"
             },
-            "time": "2025-04-23T22:37:01+00:00"
+            "time": "2024-09-18T22:04:15+00:00"
         },
         {
             "name": "grpc/grpc",
@@ -895,16 +895,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.3",
+            "version": "7.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
+                "reference": "d281ed313b989f213357e3be1a179f02196ac99b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
-                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d281ed313b989f213357e3be1a179f02196ac99b",
+                "reference": "d281ed313b989f213357e3be1a179f02196ac99b",
                 "shasum": ""
             },
             "require": {
@@ -1001,7 +1001,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
+                "source": "https://github.com/guzzle/guzzle/tree/7.9.2"
             },
             "funding": [
                 {
@@ -1017,20 +1017,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:37:11+00:00"
+            "time": "2024-07-24T11:22:20+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.2.0",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
+                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
-                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
+                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
                 "shasum": ""
             },
             "require": {
@@ -1084,7 +1084,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.2.0"
+                "source": "https://github.com/guzzle/promises/tree/2.0.4"
             },
             "funding": [
                 {
@@ -1100,20 +1100,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T13:27:01+00:00"
+            "time": "2024-10-17T10:06:22+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
+                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
-                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
                 "shasum": ""
             },
             "require": {
@@ -1200,7 +1200,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.7.0"
             },
             "funding": [
                 {
@@ -1216,20 +1216,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-27T12:30:47+00:00"
+            "time": "2024-07-18T11:15:46+00:00"
         },
         {
             "name": "monolog/monolog",
-            "version": "3.9.0",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+                "reference": "aef6ee73a77a66e404dd6540934a9ef1b3c855b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/aef6ee73a77a66e404dd6540934a9ef1b3c855b4",
+                "reference": "aef6ee73a77a66e404dd6540934a9ef1b3c855b4",
                 "shasum": ""
             },
             "require": {
@@ -1307,7 +1307,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.8.1"
             },
             "funding": [
                 {
@@ -1319,20 +1319,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T10:02:05+00:00"
+            "time": "2024-12-05T17:15:07+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.9.1",
+            "version": "3.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "ced71f79398ece168e24f7f7710462f462310d4d"
+                "reference": "129700ed449b1f02d70272d2ac802357c8c30c58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/ced71f79398ece168e24f7f7710462f462310d4d",
-                "reference": "ced71f79398ece168e24f7f7710462f462310d4d",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/129700ed449b1f02d70272d2ac802357c8c30c58",
+                "reference": "129700ed449b1f02d70272d2ac802357c8c30c58",
                 "shasum": ""
             },
             "require": {
@@ -1408,8 +1408,8 @@
             ],
             "support": {
                 "docs": "https://carbon.nesbot.com/docs",
-                "issues": "https://github.com/CarbonPHP/carbon/issues",
-                "source": "https://github.com/CarbonPHP/carbon"
+                "issues": "https://github.com/briannesbitt/Carbon/issues",
+                "source": "https://github.com/briannesbitt/Carbon"
             },
             "funding": [
                 {
@@ -1425,7 +1425,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-01T19:51:51+00:00"
+            "time": "2024-12-27T09:25:35+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -2007,16 +2007,16 @@
         },
         {
             "name": "ramsey/collection",
-            "version": "2.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/collection.git",
-                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2"
+                "reference": "a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/collection/zipball/344572933ad0181accbf4ba763e85a0306a8c5e2",
-                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5",
+                "reference": "a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5",
                 "shasum": ""
             },
             "require": {
@@ -2024,22 +2024,25 @@
             },
             "require-dev": {
                 "captainhook/plugin-composer": "^5.3",
-                "ergebnis/composer-normalize": "^2.45",
-                "fakerphp/faker": "^1.24",
+                "ergebnis/composer-normalize": "^2.28.3",
+                "fakerphp/faker": "^1.21",
                 "hamcrest/hamcrest-php": "^2.0",
-                "jangregor/phpstan-prophecy": "^2.1",
-                "mockery/mockery": "^1.6",
+                "jangregor/phpstan-prophecy": "^1.0",
+                "mockery/mockery": "^1.5",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.4",
-                "phpspec/prophecy-phpunit": "^2.3",
-                "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-mockery": "^2.0",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.5",
-                "ramsey/coding-standard": "^2.3",
-                "ramsey/conventional-commits": "^1.6",
-                "roave/security-advisories": "dev-latest"
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpcsstandards/phpcsutils": "^1.0.0-rc1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5",
+                "psalm/plugin-mockery": "^1.1",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "ramsey/coding-standard": "^2.0.3",
+                "ramsey/conventional-commits": "^1.3",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "extra": {
@@ -2077,9 +2080,19 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/collection/issues",
-                "source": "https://github.com/ramsey/collection/tree/2.1.1"
+                "source": "https://github.com/ramsey/collection/tree/2.0.0"
             },
-            "time": "2025-03-22T05:38:12+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/ramsey",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ramsey/collection",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-31T21:50:55+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -2313,16 +2326,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
                 "shasum": ""
             },
             "require": {
@@ -2335,7 +2348,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.5-dev"
                 }
             },
             "autoload": {
@@ -2360,7 +2373,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -2376,24 +2389,23 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.32.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
                 "shasum": ""
             },
             "require": {
-                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -2441,7 +2453,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2457,20 +2469,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.32.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
                 "shasum": ""
             },
             "require": {
@@ -2521,7 +2533,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2537,11 +2549,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.32.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
@@ -2597,7 +2609,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -2617,16 +2629,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v7.2.6",
+            "version": "v7.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "e7fd8e2a4239b79a0fd9fb1fef3e0e7f969c6dc6"
+                "reference": "e2674a30132b7cc4d74540d6c2573aa363f05923"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/e7fd8e2a4239b79a0fd9fb1fef3e0e7f969c6dc6",
-                "reference": "e7fd8e2a4239b79a0fd9fb1fef3e0e7f969c6dc6",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/e2674a30132b7cc4d74540d6c2573aa363f05923",
+                "reference": "e2674a30132b7cc4d74540d6c2573aa363f05923",
                 "shasum": ""
             },
             "require": {
@@ -2692,7 +2704,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.2.6"
+                "source": "https://github.com/symfony/translation/tree/v7.2.2"
             },
             "funding": [
                 {
@@ -2708,20 +2720,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-07T19:09:28+00:00"
+            "time": "2024-12-07T08:18:10+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d"
+                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
-                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/4667ff3bd513750603a09c8dedbea942487fb07c",
+                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c",
                 "shasum": ""
             },
             "require": {
@@ -2734,7 +2746,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.5-dev"
                 }
             },
             "autoload": {
@@ -2770,7 +2782,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -2786,7 +2798,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-27T08:32:26+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "yananob/my-gcp-tools",
@@ -2794,12 +2806,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/yananob/my-gcp-tools.git",
-                "reference": "709d19cc379977b539b2c24dcef3e9ae29478392"
+                "reference": "2c615ff90eb8024c954d4ac3e89571260bae17dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yananob/my-gcp-tools/zipball/709d19cc379977b539b2c24dcef3e9ae29478392",
-                "reference": "709d19cc379977b539b2c24dcef3e9ae29478392",
+                "url": "https://api.github.com/repos/yananob/my-gcp-tools/zipball/2c615ff90eb8024c954d4ac3e89571260bae17dd",
+                "reference": "2c615ff90eb8024c954d4ac3e89571260bae17dd",
                 "shasum": ""
             },
             "require": {
@@ -2821,7 +2833,7 @@
                 "source": "https://github.com/yananob/my-gcp-tools/tree/main",
                 "issues": "https://github.com/yananob/my-gcp-tools/issues"
             },
-            "time": "2025-04-26T11:20:32+00:00"
+            "time": "2025-01-12T03:46:49+00:00"
         },
         {
             "name": "yananob/my-tools",
@@ -2829,17 +2841,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/yananob/my-tools.git",
-                "reference": "14fdf33fae535f749fa83b356bb0c6485c4b71f6"
+                "reference": "03095c41da8d62df684e783c52b025894875c5ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yananob/my-tools/zipball/14fdf33fae535f749fa83b356bb0c6485c4b71f6",
-                "reference": "14fdf33fae535f749fa83b356bb0c6485c4b71f6",
+                "url": "https://api.github.com/repos/yananob/my-tools/zipball/03095c41da8d62df684e783c52b025894875c5ba",
+                "reference": "03095c41da8d62df684e783c52b025894875c5ba",
                 "shasum": ""
             },
             "require": {
                 "google/apiclient": "^2.0",
-                "nesbot/carbon": "^3.8",
                 "php": ">= 8.2"
             },
             "require-dev": {
@@ -2858,22 +2869,22 @@
                 "source": "https://github.com/yananob/my-tools/tree/main",
                 "issues": "https://github.com/yananob/my-tools/issues"
             },
-            "time": "2025-04-22T11:29:00+00:00"
+            "time": "2025-01-05T04:01:45+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.1",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
@@ -2912,7 +2923,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
             },
             "funding": [
                 {
@@ -2920,7 +2931,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T12:36:36+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3100,16 +3111,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.27",
+            "version": "1.12.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162"
+                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3a6e423c076ab39dfedc307e2ac627ef579db162",
-                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c91d4e8bc056f46cf653656e6f71004b254574d1",
+                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1",
                 "shasum": ""
             },
             "require": {
@@ -3154,7 +3165,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-21T20:51:45+00:00"
+            "time": "2025-01-05T16:40:22+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3479,16 +3490,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.46",
+            "version": "10.5.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "8080be387a5be380dda48c6f41cee4a13aadab3d"
+                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8080be387a5be380dda48c6f41cee4a13aadab3d",
-                "reference": "8080be387a5be380dda48c6f41cee4a13aadab3d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e6ddda95af52f69c1e0c7b4f977cccb58048798c",
+                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c",
                 "shasum": ""
             },
             "require": {
@@ -3498,7 +3509,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.1",
+                "myclabs/deep-copy": "^1.12.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
@@ -3560,7 +3571,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.46"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.40"
             },
             "funding": [
                 {
@@ -3572,19 +3583,11 @@
                     "type": "github"
                 },
                 {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-02T06:46:24+00:00"
+            "time": "2024-12-21T05:49:06+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1abea3e6c2ec9c662ade79084ad9242d",
+    "content-hash": "03d47b867af1db32d764d60c5fae152b",
     "packages": [
         {
             "name": "brick/math",
-            "version": "0.12.1",
+            "version": "0.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "f510c0a40911935b77b86859eb5223d58d660df1"
+                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/f510c0a40911935b77b86859eb5223d58d660df1",
-                "reference": "f510c0a40911935b77b86859eb5223d58d660df1",
+                "url": "https://api.github.com/repos/brick/math/zipball/866551da34e9a618e64a819ee1e01c20d8a588ba",
+                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
                 "phpunit/phpunit": "^10.1",
-                "vimeo/psalm": "5.16.0"
+                "vimeo/psalm": "6.8.8"
             },
             "type": "library",
             "autoload": {
@@ -56,7 +56,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.12.1"
+                "source": "https://github.com/brick/math/tree/0.12.3"
             },
             "funding": [
                 {
@@ -64,7 +64,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-29T23:19:16+00:00"
+            "time": "2025-02-28T13:11:00+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -137,16 +137,16 @@
         },
         {
             "name": "cloudevents/sdk-php",
-            "version": "v1.1.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cloudevents/sdk-php.git",
-                "reference": "45c5e1b5c4734bbba2e23ae41d06e7902d35087b"
+                "reference": "2d2f14720c83e4ef2b8e17250817b25d59ba055b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cloudevents/sdk-php/zipball/45c5e1b5c4734bbba2e23ae41d06e7902d35087b",
-                "reference": "45c5e1b5c4734bbba2e23ae41d06e7902d35087b",
+                "url": "https://api.github.com/repos/cloudevents/sdk-php/zipball/2d2f14720c83e4ef2b8e17250817b25d59ba055b",
+                "reference": "2d2f14720c83e4ef2b8e17250817b25d59ba055b",
                 "shasum": ""
             },
             "require": {
@@ -159,7 +159,7 @@
                 "guzzlehttp/psr7": "^2.4.3",
                 "php-http/discovery": "^1.15.2",
                 "phpunit/phpunit": "^9.6.3 || ^10.0.12",
-                "psalm/phar": "5.7.6",
+                "psalm/phar": "5.26.1",
                 "psr/http-factory": "^1.0.1",
                 "psr/http-message": "^1.0.1",
                 "squizlabs/php_codesniffer": "3.7.2"
@@ -174,7 +174,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.1-dev"
+                    "dev-main": "1.2-dev"
                 }
             },
             "autoload": {
@@ -191,20 +191,20 @@
                 "issues": "https://github.com/cloudevents/sdk-php/issues",
                 "source": "https://github.com/cloudevents/sdk-php"
             },
-            "time": "2023-12-18T02:56:02+00:00"
+            "time": "2025-02-07T18:31:27+00:00"
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.10.2",
+            "version": "v6.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "30c19ed0f3264cb660ea496895cfb6ef7ee3653b"
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/30c19ed0f3264cb660ea496895cfb6ef7ee3653b",
-                "reference": "30c19ed0f3264cb660ea496895cfb6ef7ee3653b",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
                 "shasum": ""
             },
             "require": {
@@ -252,22 +252,22 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.10.2"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
             },
-            "time": "2024-11-24T11:22:49+00:00"
+            "time": "2025-04-09T20:32:01+00:00"
         },
         {
             "name": "google/apiclient",
-            "version": "v2.18.2",
+            "version": "v2.18.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "d8d201ba8a189a3cd7fb34e4da569f2ed440eee7"
+                "reference": "4eee42d201eff054428a4836ec132944d271f051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/d8d201ba8a189a3cd7fb34e4da569f2ed440eee7",
-                "reference": "d8d201ba8a189a3cd7fb34e4da569f2ed440eee7",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/4eee42d201eff054428a4836ec132944d271f051",
+                "reference": "4eee42d201eff054428a4836ec132944d271f051",
                 "shasum": ""
             },
             "require": {
@@ -321,22 +321,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client/issues",
-                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.18.2"
+                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.18.3"
             },
-            "time": "2024-12-16T22:52:40+00:00"
+            "time": "2025-04-08T21:59:36+00:00"
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.389.0",
+            "version": "v0.396.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "6274e67ee52b1a416ccee0a4eaf337d1139cdaf8"
+                "reference": "ceb2e432e4326c6775d24f62d554395a1a9ad3dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/6274e67ee52b1a416ccee0a4eaf337d1139cdaf8",
-                "reference": "6274e67ee52b1a416ccee0a4eaf337d1139cdaf8",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/ceb2e432e4326c6775d24f62d554395a1a9ad3dd",
+                "reference": "ceb2e432e4326c6775d24f62d554395a1a9ad3dd",
                 "shasum": ""
             },
             "require": {
@@ -365,22 +365,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.389.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.396.0"
             },
-            "time": "2025-01-05T01:04:21+00:00"
+            "time": "2025-02-24T01:10:27+00:00"
         },
         {
             "name": "google/auth",
-            "version": "v1.45.0",
+            "version": "v1.47.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-auth-library-php.git",
-                "reference": "cfcb93162341ed5022fa976e621f0fa2b05ba6ad"
+                "reference": "d6389aae7c009daceaa8da9b7942d8df6969f6d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/cfcb93162341ed5022fa976e621f0fa2b05ba6ad",
-                "reference": "cfcb93162341ed5022fa976e621f0fa2b05ba6ad",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/d6389aae7c009daceaa8da9b7942d8df6969f6d9",
+                "reference": "d6389aae7c009daceaa8da9b7942d8df6969f6d9",
                 "shasum": ""
             },
             "require": {
@@ -417,43 +417,43 @@
                 "Apache-2.0"
             ],
             "description": "Google Auth Library for PHP",
-            "homepage": "http://github.com/google/google-auth-library-php",
+            "homepage": "https://github.com/google/google-auth-library-php",
             "keywords": [
                 "Authentication",
                 "google",
                 "oauth2"
             ],
             "support": {
-                "docs": "https://googleapis.github.io/google-auth-library-php/main/",
+                "docs": "https://cloud.google.com/php/docs/reference/auth/latest",
                 "issues": "https://github.com/googleapis/google-auth-library-php/issues",
-                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.45.0"
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.47.0"
             },
-            "time": "2024-12-11T02:10:48+00:00"
+            "time": "2025-04-15T21:47:20+00:00"
         },
         {
             "name": "google/cloud-core",
-            "version": "v1.61.0",
+            "version": "v1.62.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-cloud-php-core.git",
-                "reference": "c2cd6aff17704dd5a59e2c1c802509f9e82d36fd"
+                "reference": "0c19d76e7f3b6810c4f2cc1330c693af2681c601"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/c2cd6aff17704dd5a59e2c1c802509f9e82d36fd",
-                "reference": "c2cd6aff17704dd5a59e2c1c802509f9e82d36fd",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/0c19d76e7f3b6810c4f2cc1330c693af2681c601",
+                "reference": "0c19d76e7f3b6810c4f2cc1330c693af2681c601",
                 "shasum": ""
             },
             "require": {
                 "google/auth": "^1.34",
                 "google/gax": "^1.36.0",
-                "guzzlehttp/guzzle": "^6.5.8|^7.4.4",
+                "guzzlehttp/guzzle": "^6.5.8||^7.4.4",
                 "guzzlehttp/promises": "^1.4||^2.0",
                 "guzzlehttp/psr7": "^2.6",
-                "monolog/monolog": "^2.9|^3.0",
+                "monolog/monolog": "^2.9||^3.0",
                 "php": "^8.0",
-                "psr/http-message": "^1.0|^2.0",
-                "rize/uri-template": "~0.3"
+                "psr/http-message": "^1.0||^2.0",
+                "rize/uri-template": "~0.3||~0.4"
             },
             "require-dev": {
                 "erusev/parsedown": "^1.6",
@@ -492,22 +492,22 @@
             ],
             "description": "Google Cloud PHP shared dependency, providing functionality useful to all components.",
             "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.61.0"
+                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.62.3"
             },
-            "time": "2025-01-11T02:14:50+00:00"
+            "time": "2025-05-20T19:49:54+00:00"
         },
         {
             "name": "google/cloud-firestore",
-            "version": "v1.47.3",
+            "version": "v1.50.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-cloud-php-firestore.git",
-                "reference": "a7a2e065dc6c6ccc87fec3a96b4bcbb5e49fb662"
+                "reference": "22d883035f77dce56936cc1909159b8858bcb0b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-firestore/zipball/a7a2e065dc6c6ccc87fec3a96b4bcbb5e49fb662",
-                "reference": "a7a2e065dc6c6ccc87fec3a96b4bcbb5e49fb662",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-firestore/zipball/22d883035f77dce56936cc1909159b8858bcb0b6",
+                "reference": "22d883035f77dce56936cc1909159b8858bcb0b6",
                 "shasum": ""
             },
             "require": {
@@ -549,9 +549,9 @@
             ],
             "description": "Cloud Firestore Client for PHP",
             "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-firestore/tree/v1.47.3"
+                "source": "https://github.com/googleapis/google-cloud-php-firestore/tree/v1.50.0"
             },
-            "time": "2025-01-11T02:14:50+00:00"
+            "time": "2025-04-18T20:49:28+00:00"
         },
         {
             "name": "google/cloud-functions-framework",
@@ -602,16 +602,16 @@
         },
         {
             "name": "google/common-protos",
-            "version": "4.9.0",
+            "version": "4.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/common-protos-php.git",
-                "reference": "a2d1a583819286db5ef9403c6a2bfa29c9636c46"
+                "reference": "70c4eb1abab5484a23c17a43b0d455259f5d8c1b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/a2d1a583819286db5ef9403c6a2bfa29c9636c46",
-                "reference": "a2d1a583819286db5ef9403c6a2bfa29c9636c46",
+                "url": "https://api.github.com/repos/googleapis/common-protos-php/zipball/70c4eb1abab5484a23c17a43b0d455259f5d8c1b",
+                "reference": "70c4eb1abab5484a23c17a43b0d455259f5d8c1b",
                 "shasum": ""
             },
             "require": {
@@ -655,22 +655,22 @@
                 "google"
             ],
             "support": {
-                "source": "https://github.com/googleapis/common-protos-php/tree/v4.9.0"
+                "source": "https://github.com/googleapis/common-protos-php/tree/v4.12.1"
             },
-            "time": "2025-01-11T02:14:50+00:00"
+            "time": "2025-05-20T19:49:54+00:00"
         },
         {
             "name": "google/gax",
-            "version": "v1.36.0",
+            "version": "v1.36.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/gax-php.git",
-                "reference": "140599cf5eae2432363ce6198e9fdff851625a7a"
+                "reference": "afdac3bc38a3b17d70668115d7b1a97289ac4d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/140599cf5eae2432363ce6198e9fdff851625a7a",
-                "reference": "140599cf5eae2432363ce6198e9fdff851625a7a",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/afdac3bc38a3b17d70668115d7b1a97289ac4d72",
+                "reference": "afdac3bc38a3b17d70668115d7b1a97289ac4d72",
                 "shasum": ""
             },
             "require": {
@@ -712,22 +712,22 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/gax-php/issues",
-                "source": "https://github.com/googleapis/gax-php/tree/v1.36.0"
+                "source": "https://github.com/googleapis/gax-php/tree/v1.36.1"
             },
-            "time": "2024-12-11T02:47:43+00:00"
+            "time": "2025-05-20T19:50:43+00:00"
         },
         {
             "name": "google/grpc-gcp",
-            "version": "v0.4.0",
+            "version": "v0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GoogleCloudPlatform/grpc-gcp-php.git",
-                "reference": "2a80dbf690922aa52bb6bb79b9a32a9637a5c2d9"
+                "reference": "e585b7721bbe806ef45b5c52ae43dfc2bff89968"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/2a80dbf690922aa52bb6bb79b9a32a9637a5c2d9",
-                "reference": "2a80dbf690922aa52bb6bb79b9a32a9637a5c2d9",
+                "url": "https://api.github.com/repos/GoogleCloudPlatform/grpc-gcp-php/zipball/e585b7721bbe806ef45b5c52ae43dfc2bff89968",
+                "reference": "e585b7721bbe806ef45b5c52ae43dfc2bff89968",
                 "shasum": ""
             },
             "require": {
@@ -757,22 +757,22 @@
             "description": "gRPC GCP library for channel management",
             "support": {
                 "issues": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/issues",
-                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.4.0"
+                "source": "https://github.com/GoogleCloudPlatform/grpc-gcp-php/tree/v0.4.1"
             },
-            "time": "2024-04-03T16:37:55+00:00"
+            "time": "2025-02-19T21:53:22+00:00"
         },
         {
             "name": "google/longrunning",
-            "version": "0.4.6",
+            "version": "0.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/php-longrunning.git",
-                "reference": "4eb04d47bba8095d5a47f75334b9204c2a4a7ac6"
+                "reference": "624cabb874c10e5ddc9034c999f724894b70a3d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/php-longrunning/zipball/4eb04d47bba8095d5a47f75334b9204c2a4a7ac6",
-                "reference": "4eb04d47bba8095d5a47f75334b9204c2a4a7ac6",
+                "url": "https://api.github.com/repos/googleapis/php-longrunning/zipball/624cabb874c10e5ddc9034c999f724894b70a3d3",
+                "reference": "624cabb874c10e5ddc9034c999f724894b70a3d3",
                 "shasum": ""
             },
             "require-dev": {
@@ -801,22 +801,22 @@
             ],
             "description": "Google LongRunning Client for PHP",
             "support": {
-                "source": "https://github.com/googleapis/php-longrunning/tree/v0.4.6"
+                "source": "https://github.com/googleapis/php-longrunning/tree/v0.4.7"
             },
-            "time": "2024-12-12T21:15:35+00:00"
+            "time": "2025-01-24T21:24:06+00:00"
         },
         {
             "name": "google/protobuf",
-            "version": "v3.25.5",
+            "version": "v3.25.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/protocolbuffers/protobuf-php.git",
-                "reference": "dd2cf3f7b577dced3851c2ea76c3daa9f8aa0ff4"
+                "reference": "6901ac6aed67882732a47d877d4dbd6189cbdcf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/dd2cf3f7b577dced3851c2ea76c3daa9f8aa0ff4",
-                "reference": "dd2cf3f7b577dced3851c2ea76c3daa9f8aa0ff4",
+                "url": "https://api.github.com/repos/protocolbuffers/protobuf-php/zipball/6901ac6aed67882732a47d877d4dbd6189cbdcf2",
+                "reference": "6901ac6aed67882732a47d877d4dbd6189cbdcf2",
                 "shasum": ""
             },
             "require": {
@@ -845,9 +845,9 @@
                 "proto"
             ],
             "support": {
-                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.25.5"
+                "source": "https://github.com/protocolbuffers/protobuf-php/tree/v3.25.7"
             },
-            "time": "2024-09-18T22:04:15+00:00"
+            "time": "2025-04-23T22:37:01+00:00"
         },
         {
             "name": "grpc/grpc",
@@ -895,16 +895,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.2",
+            "version": "7.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "d281ed313b989f213357e3be1a179f02196ac99b"
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d281ed313b989f213357e3be1a179f02196ac99b",
-                "reference": "d281ed313b989f213357e3be1a179f02196ac99b",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
                 "shasum": ""
             },
             "require": {
@@ -1001,7 +1001,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
             },
             "funding": [
                 {
@@ -1017,20 +1017,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-24T11:22:20+00:00"
+            "time": "2025-03-27T13:37:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.4",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455"
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
-                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
                 "shasum": ""
             },
             "require": {
@@ -1084,7 +1084,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.4"
+                "source": "https://github.com/guzzle/promises/tree/2.2.0"
             },
             "funding": [
                 {
@@ -1100,20 +1100,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-17T10:06:22+00:00"
+            "time": "2025-03-27T13:27:01+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201"
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
                 "shasum": ""
             },
             "require": {
@@ -1200,7 +1200,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
             },
             "funding": [
                 {
@@ -1216,20 +1216,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-18T11:15:46+00:00"
+            "time": "2025-03-27T12:30:47+00:00"
         },
         {
             "name": "monolog/monolog",
-            "version": "3.8.1",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "aef6ee73a77a66e404dd6540934a9ef1b3c855b4"
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/aef6ee73a77a66e404dd6540934a9ef1b3c855b4",
-                "reference": "aef6ee73a77a66e404dd6540934a9ef1b3c855b4",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
                 "shasum": ""
             },
             "require": {
@@ -1307,7 +1307,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.8.1"
+                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
             },
             "funding": [
                 {
@@ -1319,20 +1319,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-05T17:15:07+00:00"
+            "time": "2025-03-24T10:02:05+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.8.4",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "129700ed449b1f02d70272d2ac802357c8c30c58"
+                "reference": "ced71f79398ece168e24f7f7710462f462310d4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/129700ed449b1f02d70272d2ac802357c8c30c58",
-                "reference": "129700ed449b1f02d70272d2ac802357c8c30c58",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/ced71f79398ece168e24f7f7710462f462310d4d",
+                "reference": "ced71f79398ece168e24f7f7710462f462310d4d",
                 "shasum": ""
             },
             "require": {
@@ -1408,8 +1408,8 @@
             ],
             "support": {
                 "docs": "https://carbon.nesbot.com/docs",
-                "issues": "https://github.com/briannesbitt/Carbon/issues",
-                "source": "https://github.com/briannesbitt/Carbon"
+                "issues": "https://github.com/CarbonPHP/carbon/issues",
+                "source": "https://github.com/CarbonPHP/carbon"
             },
             "funding": [
                 {
@@ -1425,7 +1425,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-27T09:25:35+00:00"
+            "time": "2025-05-01T19:51:51+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -2007,16 +2007,16 @@
         },
         {
             "name": "ramsey/collection",
-            "version": "2.0.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/collection.git",
-                "reference": "a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5"
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/collection/zipball/a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5",
-                "reference": "a4b48764bfbb8f3a6a4d1aeb1a35bb5e9ecac4a5",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2",
                 "shasum": ""
             },
             "require": {
@@ -2024,25 +2024,22 @@
             },
             "require-dev": {
                 "captainhook/plugin-composer": "^5.3",
-                "ergebnis/composer-normalize": "^2.28.3",
-                "fakerphp/faker": "^1.21",
+                "ergebnis/composer-normalize": "^2.45",
+                "fakerphp/faker": "^1.24",
                 "hamcrest/hamcrest-php": "^2.0",
-                "jangregor/phpstan-prophecy": "^1.0",
-                "mockery/mockery": "^1.5",
+                "jangregor/phpstan-prophecy": "^2.1",
+                "mockery/mockery": "^1.6",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3",
-                "phpcsstandards/phpcsutils": "^1.0.0-rc1",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpstan/extension-installer": "^1.2",
-                "phpstan/phpstan": "^1.9",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5",
-                "psalm/plugin-mockery": "^1.1",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "ramsey/coding-standard": "^2.0.3",
-                "ramsey/conventional-commits": "^1.3",
-                "vimeo/psalm": "^5.4"
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpspec/prophecy-phpunit": "^2.3",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5",
+                "ramsey/coding-standard": "^2.3",
+                "ramsey/conventional-commits": "^1.6",
+                "roave/security-advisories": "dev-latest"
             },
             "type": "library",
             "extra": {
@@ -2080,19 +2077,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/collection/issues",
-                "source": "https://github.com/ramsey/collection/tree/2.0.0"
+                "source": "https://github.com/ramsey/collection/tree/2.1.1"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/ramsey",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/ramsey/collection",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-31T21:50:55+00:00"
+            "time": "2025-03-22T05:38:12+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -2326,16 +2313,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -2348,7 +2335,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -2373,7 +2360,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -2389,23 +2376,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
+                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -2453,7 +2441,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2469,20 +2457,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
@@ -2533,7 +2521,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2549,11 +2537,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
@@ -2609,7 +2597,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -2629,16 +2617,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v7.2.2",
+            "version": "v7.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "e2674a30132b7cc4d74540d6c2573aa363f05923"
+                "reference": "e7fd8e2a4239b79a0fd9fb1fef3e0e7f969c6dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/e2674a30132b7cc4d74540d6c2573aa363f05923",
-                "reference": "e2674a30132b7cc4d74540d6c2573aa363f05923",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/e7fd8e2a4239b79a0fd9fb1fef3e0e7f969c6dc6",
+                "reference": "e7fd8e2a4239b79a0fd9fb1fef3e0e7f969c6dc6",
                 "shasum": ""
             },
             "require": {
@@ -2704,7 +2692,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.2.2"
+                "source": "https://github.com/symfony/translation/tree/v7.2.6"
             },
             "funding": [
                 {
@@ -2720,20 +2708,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-07T08:18:10+00:00"
+            "time": "2025-04-07T19:09:28+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c"
+                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/4667ff3bd513750603a09c8dedbea942487fb07c",
-                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
+                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
                 "shasum": ""
             },
             "require": {
@@ -2746,7 +2734,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -2782,7 +2770,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -2798,7 +2786,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-27T08:32:26+00:00"
         },
         {
             "name": "yananob/my-gcp-tools",
@@ -2806,12 +2794,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/yananob/my-gcp-tools.git",
-                "reference": "2c615ff90eb8024c954d4ac3e89571260bae17dd"
+                "reference": "709d19cc379977b539b2c24dcef3e9ae29478392"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yananob/my-gcp-tools/zipball/2c615ff90eb8024c954d4ac3e89571260bae17dd",
-                "reference": "2c615ff90eb8024c954d4ac3e89571260bae17dd",
+                "url": "https://api.github.com/repos/yananob/my-gcp-tools/zipball/709d19cc379977b539b2c24dcef3e9ae29478392",
+                "reference": "709d19cc379977b539b2c24dcef3e9ae29478392",
                 "shasum": ""
             },
             "require": {
@@ -2833,7 +2821,7 @@
                 "source": "https://github.com/yananob/my-gcp-tools/tree/main",
                 "issues": "https://github.com/yananob/my-gcp-tools/issues"
             },
-            "time": "2025-01-12T03:46:49+00:00"
+            "time": "2025-04-26T11:20:32+00:00"
         },
         {
             "name": "yananob/my-tools",
@@ -2841,16 +2829,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/yananob/my-tools.git",
-                "reference": "03095c41da8d62df684e783c52b025894875c5ba"
+                "reference": "14fdf33fae535f749fa83b356bb0c6485c4b71f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yananob/my-tools/zipball/03095c41da8d62df684e783c52b025894875c5ba",
-                "reference": "03095c41da8d62df684e783c52b025894875c5ba",
+                "url": "https://api.github.com/repos/yananob/my-tools/zipball/14fdf33fae535f749fa83b356bb0c6485c4b71f6",
+                "reference": "14fdf33fae535f749fa83b356bb0c6485c4b71f6",
                 "shasum": ""
             },
             "require": {
                 "google/apiclient": "^2.0",
+                "nesbot/carbon": "^3.8",
                 "php": ">= 8.2"
             },
             "require-dev": {
@@ -2869,22 +2858,22 @@
                 "source": "https://github.com/yananob/my-tools/tree/main",
                 "issues": "https://github.com/yananob/my-tools/issues"
             },
-            "time": "2025-01-05T04:01:45+00:00"
+            "time": "2025-04-22T11:29:00+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
                 "shasum": ""
             },
             "require": {
@@ -2923,7 +2912,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
             },
             "funding": [
                 {
@@ -2931,7 +2920,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2025-04-29T12:36:36+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3111,16 +3100,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.15",
+            "version": "1.12.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1"
+                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c91d4e8bc056f46cf653656e6f71004b254574d1",
-                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3a6e423c076ab39dfedc307e2ac627ef579db162",
+                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162",
                 "shasum": ""
             },
             "require": {
@@ -3165,7 +3154,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-05T16:40:22+00:00"
+            "time": "2025-05-21T20:51:45+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3490,16 +3479,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.40",
+            "version": "10.5.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c"
+                "reference": "8080be387a5be380dda48c6f41cee4a13aadab3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e6ddda95af52f69c1e0c7b4f977cccb58048798c",
-                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8080be387a5be380dda48c6f41cee4a13aadab3d",
+                "reference": "8080be387a5be380dda48c6f41cee4a13aadab3d",
                 "shasum": ""
             },
             "require": {
@@ -3509,7 +3498,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
@@ -3571,7 +3560,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.40"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.46"
             },
             "funding": [
                 {
@@ -3583,11 +3572,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-21T05:49:06+00:00"
+            "time": "2025-05-02T06:46:24+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/configs/search_api.json.sample
+++ b/configs/search_api.json.sample
@@ -1,0 +1,4 @@
+{
+    "google_custom_search_api_key": "YOUR_GOOGLE_API_KEY",
+    "google_custom_search_cx_id": "YOUR_CUSTOM_SEARCH_ENGINE_ID"
+}

--- a/src/PersonalBot.php
+++ b/src/PersonalBot.php
@@ -10,7 +10,7 @@ use yananob\MyTools\Utils;
 use yananob\MyTools\Gpt;
 use MyApp\WebSearchTool; // For the refactored tool
 use Google_Client;       // If not already present implicitly
-use Google_Service_Customsearch; // If not already present implicitly
+use Google\Service\CustomSearchAPI; // If not already present implicitly
 use Exception;           // For general error handling if needed during instantiation
 
 // TODO: extends GptBot
@@ -76,7 +76,7 @@ EOM;
             try {
                 $client = new Google_Client();
                 $client->setDeveloperKey($this->googleApiKey);
-                $customSearchService = new Google_Service_Customsearch($client);
+                $customSearchService = new CustomSearchAPI($client);
                 $this->webSearchTool = new WebSearchTool($customSearchService);
             } catch (Exception $e) {
                 // Log this error in a real application

--- a/src/PersonalBot.php
+++ b/src/PersonalBot.php
@@ -99,8 +99,8 @@ EOM;
             // Call the non-static search method on the instance
             $webSearchResults = $this->webSearchTool->search(
                 $searchQuery,
-                $this->googleCxId 
-                // numResults can be passed if needed, e.g., 3
+                $this->googleCxId,
+                5
             );
         } elseif (empty($this->googleApiKey) && $this->__shouldPerformWebSearch($message)) {
             // Case where search was desired, but API key was missing (webSearchTool not initialized)

--- a/src/WebSearchTool.php
+++ b/src/WebSearchTool.php
@@ -6,7 +6,7 @@ namespace MyApp;
 
 // Add these if not present (assuming google/apiclient is available)
 use Google_Client;
-use Google_Service_Customsearch;
+use Google\Service\CustomSearchAPI;
 use Exception; // For error handling
 
 class WebSearchTool
@@ -29,7 +29,7 @@ class WebSearchTool
         try {
             $client = new Google_Client();
             $client->setDeveloperKey($apiKey);
-            $service = new Google_Service_Customsearch($client);
+            $service = new CustomSearchAPI($client);
 
             $params = [
                 'q' => $query,

--- a/src/WebSearchTool.php
+++ b/src/WebSearchTool.php
@@ -4,45 +4,52 @@ declare(strict_types=1);
 
 namespace MyApp;
 
-// Add these if not present (assuming google/apiclient is available)
-use Google_Client;
-use Google\Service\CustomSearchAPI;
-use Exception; // For error handling
+use Google_Service_Customsearch;
+use Exception;
 
 class WebSearchTool
 {
+    private Google_Service_Customsearch $customSearchService;
+
     /**
-     * Performs a web search using Google Custom Search API.
+     * Constructor.
+     *
+     * @param Google_Service_Customsearch $customSearchService An initialized Google Custom Search service client.
+     */
+    public function __construct(Google_Service_Customsearch $customSearchService)
+    {
+        $this->customSearchService = $customSearchService;
+    }
+
+    /**
+     * Performs a web search using the injected Google Custom Search API service.
      *
      * @param string $query The search query.
-     * @param string $apiKey The Google API Key.
      * @param string $cx The Custom Search Engine ID (CX).
-     * @param int $numResults Number of results to fetch (default 3).
+     * @param int $numResults Number of results to fetch.
      * @return string A summary of the search results, or an error message.
      */
-    public static function search(string $query, string $apiKey, string $cx, int $numResults = 3): string
+    public function search(string $query, string $cx, int $numResults = 3): string
     {
-        if (empty($apiKey) || empty($cx)) {
-            return "Error: API key or CX ID is not configured for web search.";
+        if (empty($cx)) {
+            // CX ID is essential for the call itself.
+            return "Error: Custom Search Engine ID (CX) is not provided for web search.";
         }
 
         try {
-            $client = new Google_Client();
-            $client->setDeveloperKey($apiKey);
-            $service = new CustomSearchAPI($client);
-
             $params = [
                 'q' => $query,
                 'cx' => $cx,
                 'num' => $numResults
             ];
 
-            $results = $service->cse->listCse($params);
+            // $this->customSearchService is already an instance of Google_Service_Customsearch
+            $results = $this->customSearchService->cse->listCse($params);
             
             $searchItems = $results->getItems();
 
             if (empty($searchItems)) {
-                return "No web search results found for: " . $query;
+                return "No web search results found for: " . htmlspecialchars($query);
             }
 
             $summary = [];
@@ -59,17 +66,19 @@ class WebSearchTool
             }
 
             if (empty($summary)) {
-                return "Could not extract useful information from search results for: " . $query;
+                return "Could not extract useful information from search results for: " . htmlspecialchars($query);
             }
             
+            // Return up to $numResults summaries
             return "Web Search Results:
 - " . implode("
 - ", array_slice($summary, 0, $numResults));
 
         } catch (Exception $e) {
             // Log the actual error in a real application
-            // error_log("Google Custom Search API error: " . $e->getMessage());
-            return "Error performing web search: " . $e->getMessage();
+            // error_log("Google Custom Search API error in WebSearchTool: " . $e->getMessage());
+            // Provide a more generic message to the user/bot context
+            return "Error performing web search. Details: " . $e->getMessage();
         }
     }
 }

--- a/src/WebSearchTool.php
+++ b/src/WebSearchTool.php
@@ -4,19 +4,19 @@ declare(strict_types=1);
 
 namespace MyApp;
 
-use Google_Service_Customsearch;
+use Google\Service\CustomSearchAPI;
 use Exception;
 
 class WebSearchTool
 {
-    private Google_Service_Customsearch $customSearchService;
+    private CustomSearchAPI $customSearchService;
 
     /**
      * Constructor.
      *
-     * @param Google_Service_Customsearch $customSearchService An initialized Google Custom Search service client.
+     * @param CustomSearchAPI $customSearchService An initialized Google Custom Search service client.
      */
-    public function __construct(Google_Service_Customsearch $customSearchService)
+    public function __construct(CustomSearchAPI $customSearchService)
     {
         $this->customSearchService = $customSearchService;
     }

--- a/src/WebSearchTool.php
+++ b/src/WebSearchTool.php
@@ -68,9 +68,9 @@ class WebSearchTool
             if (empty($summary)) {
                 return "Could not extract useful information from search results for: " . htmlspecialchars($query);
             }
-            
+
             // Return up to $numResults summaries
-            return "Web Search Results:
+            return "
 - " . implode("
 - ", array_slice($summary, 0, $numResults));
 

--- a/src/WebSearchTool.php
+++ b/src/WebSearchTool.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp;
+
+class WebSearchTool
+{
+    /**
+     * Performs a web search for the given query and returns a summary.
+     *
+     * For now, this is a placeholder and will return a dummy string.
+     * In a real implementation, this method would call a search engine API.
+     *
+     * @param string $query The search query.
+     * @return string A summary of the search results.
+     */
+    public static function search(string $query): string
+    {
+        // Placeholder implementation
+        // In a real scenario, you would use an HTTP client to call a search engine API
+        // and then parse the results to create a summary.
+        return "Placeholder search results for query: " . $query;
+    }
+}

--- a/src/WebSearchTool.php
+++ b/src/WebSearchTool.php
@@ -4,22 +4,72 @@ declare(strict_types=1);
 
 namespace MyApp;
 
+// Add these if not present (assuming google/apiclient is available)
+use Google_Client;
+use Google_Service_Customsearch;
+use Exception; // For error handling
+
 class WebSearchTool
 {
     /**
-     * Performs a web search for the given query and returns a summary.
-     *
-     * For now, this is a placeholder and will return a dummy string.
-     * In a real implementation, this method would call a search engine API.
+     * Performs a web search using Google Custom Search API.
      *
      * @param string $query The search query.
-     * @return string A summary of the search results.
+     * @param string $apiKey The Google API Key.
+     * @param string $cx The Custom Search Engine ID (CX).
+     * @param int $numResults Number of results to fetch (default 3).
+     * @return string A summary of the search results, or an error message.
      */
-    public static function search(string $query): string
+    public static function search(string $query, string $apiKey, string $cx, int $numResults = 3): string
     {
-        // Placeholder implementation
-        // In a real scenario, you would use an HTTP client to call a search engine API
-        // and then parse the results to create a summary.
-        return "Placeholder search results for query: " . $query;
+        if (empty($apiKey) || empty($cx)) {
+            return "Error: API key or CX ID is not configured for web search.";
+        }
+
+        try {
+            $client = new Google_Client();
+            $client->setDeveloperKey($apiKey);
+            $service = new Google_Service_Customsearch($client);
+
+            $params = [
+                'q' => $query,
+                'cx' => $cx,
+                'num' => $numResults
+            ];
+
+            $results = $service->cse->listCse($params);
+            
+            $searchItems = $results->getItems();
+
+            if (empty($searchItems)) {
+                return "No web search results found for: " . $query;
+            }
+
+            $summary = [];
+            foreach ($searchItems as $item) {
+                $title = $item->getTitle();
+                $snippet = $item->getSnippet();
+                if (!empty($title) && !empty($snippet)) {
+                    $summary[] = rtrim("Title: " . $title, '.') . ". Snippet: " . rtrim($snippet, '.') . ".";
+                } elseif (!empty($title)) {
+                    $summary[] = "Title: " . rtrim($title, '.') . ".";
+                } elseif (!empty($snippet)) {
+                    $summary[] = "Snippet: " . rtrim($snippet, '.') . ".";
+                }
+            }
+
+            if (empty($summary)) {
+                return "Could not extract useful information from search results for: " . $query;
+            }
+            
+            return "Web Search Results:
+- " . implode("
+- ", array_slice($summary, 0, $numResults));
+
+        } catch (Exception $e) {
+            // Log the actual error in a real application
+            // error_log("Google Custom Search API error: " . $e->getMessage());
+            return "Error performing web search: " . $e->getMessage();
+        }
     }
 }

--- a/tests/PersonalBotTest.php
+++ b/tests/PersonalBotTest.php
@@ -233,19 +233,19 @@ final class PersonalBotTest extends PHPUnit\Framework\TestCase
         $gptMock = $this->createMock(Gpt::class);
 
         // Expectation 1: __shouldPerformWebSearch's GPT call
-        $gptMock->expects($this->at(0))
+        $gptMock->expects(self::at(0))
                 ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_JUDGE_WEB_SEARCH, $userMessage)
                 ->willReturn('はい'); // Yes, search
 
         // Expectation 2: __generateSearchQuery's GPT call
-        $gptMock->expects($this->at(1))
+        $gptMock->expects(self::at(1))
                 ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_GENERATE_SEARCH_QUERY, $userMessage)
                 ->willReturn($dummySearchQuery);
 
         // Expectation 3: Final answer generation GPT call
-        $gptMock->expects($this->at(2))
+        $gptMock->expects(self::at(2))
                 ->method('getAnswer')
                 ->with(
                     $this->callback(function ($context) use ($expectedSearchResultsInContext) {
@@ -274,13 +274,13 @@ final class PersonalBotTest extends PHPUnit\Framework\TestCase
         $gptMock = $this->createMock(Gpt::class);
 
         // Expectation for __shouldPerformWebSearch's GPT call
-        $gptMock->expects($this->at(0)) // First call to gpt->getAnswer
+        $gptMock->expects(self::at(0)) // First call to gpt->getAnswer
                 ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_JUDGE_WEB_SEARCH, $userMessage)
                 ->willReturn('いいえ'); // No, do not search
 
         // Expectation for the final answer generation GPT call
-        $gptMock->expects($this->at(1)) // Second call to gpt->getAnswer
+        $gptMock->expects(self::at(1)) // Second call to gpt->getAnswer
                 ->method('getAnswer')
                 ->with(
                     $this->callback(function ($context) {

--- a/tests/PersonalBotTest.php
+++ b/tests/PersonalBotTest.php
@@ -234,19 +234,19 @@ final class PersonalBotTest extends PHPUnit\Framework\TestCase
         $gptMock = $this->createMock(Gpt::class);
 
         // Expectation 1: __shouldPerformWebSearch's GPT call
-        $gptMock->expects($this->at(0))
+        $gptMock->expects($this->exactly(0))
                 ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_JUDGE_WEB_SEARCH, $userMessage)
                 ->willReturn('はい'); // Yes, search
 
         // Expectation 2: __generateSearchQuery's GPT call
-        $gptMock->expects($this->at(1))
+        $gptMock->expects($this->exactly(1))
                 ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_GENERATE_SEARCH_QUERY, $userMessage)
                 ->willReturn($dummySearchQuery);
 
         // Expectation 3: Final answer generation GPT call
-        $gptMock->expects($this->at(2))
+        $gptMock->expects($this->exactly(2))
                 ->method('getAnswer')
                 ->with(
                     $this->callback(function ($context) use ($expectedSearchResultsInContext) {
@@ -275,14 +275,14 @@ final class PersonalBotTest extends PHPUnit\Framework\TestCase
         $gptMock = $this->createMock(Gpt::class);
 
         // Expectation for __shouldPerformWebSearch's GPT call
-        $gptMock->expects($this->at(0)) // First call to gpt->getAnswer
-                ->method('getAnswer')
+        $gptMock->expects($this->exactly(0)) // First call to gpt->getAnswer
+            ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_JUDGE_WEB_SEARCH, $userMessage)
                 ->willReturn('いいえ'); // No, do not search
 
         // Expectation for the final answer generation GPT call
-        $gptMock->expects($this->at(1)) // Second call to gpt->getAnswer
-                ->method('getAnswer')
+        $gptMock->expects($this->exactly(1)) // Second call to gpt->getAnswer
+            ->method('getAnswer')
                 ->with(
                     $this->callback(function ($context) {
                         $this->assertStringNotContainsString("【Web検索結果】", $context);
@@ -358,16 +358,16 @@ final class PersonalBotTest extends PHPUnit\Framework\TestCase
 
         // Mock for Gpt (for decision, query gen, and final answer)
         $gptMock = $this->createMock(Gpt::class);
-        $gptMock->expects($this->at(0)) // PROMPT_JUDGE_WEB_SEARCH
-                ->method('getAnswer')
+        $gptMock->expects($this->exactly(0)) // PROMPT_JUDGE_WEB_SEARCH
+            ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_JUDGE_WEB_SEARCH, $userMessage)
                 ->willReturn('はい');
-        $gptMock->expects($this->at(1)) // PROMPT_GENERATE_SEARCH_QUERY
-                ->method('getAnswer')
+        $gptMock->expects($this->exactly(1)) // PROMPT_GENERATE_SEARCH_QUERY
+            ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_GENERATE_SEARCH_QUERY, $userMessage)
                 ->willReturn($dummySearchQuery);
-        $gptMock->expects($this->at(2)) // Final Answer
-                ->method('getAnswer')
+        $gptMock->expects($this->exactly(2)) // Final Answer
+            ->method('getAnswer')
                 ->with(
                     $this->callback(function ($context) use ($mockedSearchResults) {
                         $this->assertStringContainsString("【Web検索結果】", $context);

--- a/tests/PersonalBotTest.php
+++ b/tests/PersonalBotTest.php
@@ -233,19 +233,19 @@ final class PersonalBotTest extends PHPUnit\Framework\TestCase
         $gptMock = $this->createMock(Gpt::class);
 
         // Expectation 1: __shouldPerformWebSearch's GPT call
-        $gptMock->expects(self::at(0))
+        $gptMock->expects($this->exactly(0))
                 ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_JUDGE_WEB_SEARCH, $userMessage)
                 ->willReturn('はい'); // Yes, search
 
         // Expectation 2: __generateSearchQuery's GPT call
-        $gptMock->expects(self::at(1))
+        $gptMock->expects($this->exactly(1))
                 ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_GENERATE_SEARCH_QUERY, $userMessage)
                 ->willReturn($dummySearchQuery);
 
         // Expectation 3: Final answer generation GPT call
-        $gptMock->expects(self::at(2))
+        $gptMock->expects($this->exactly(2))
                 ->method('getAnswer')
                 ->with(
                     $this->callback(function ($context) use ($expectedSearchResultsInContext) {
@@ -274,14 +274,14 @@ final class PersonalBotTest extends PHPUnit\Framework\TestCase
         $gptMock = $this->createMock(Gpt::class);
 
         // Expectation for __shouldPerformWebSearch's GPT call
-        $gptMock->expects(self::at(0)) // First call to gpt->getAnswer
-                ->method('getAnswer')
+        $gptMock->expects($this->exactly(0)) // First call to gpt->getAnswer
+            ->method('getAnswer')
                 ->with(PersonalBot::PROMPT_JUDGE_WEB_SEARCH, $userMessage)
                 ->willReturn('いいえ'); // No, do not search
 
         // Expectation for the final answer generation GPT call
-        $gptMock->expects(self::at(1)) // Second call to gpt->getAnswer
-                ->method('getAnswer')
+        $gptMock->expects($this->exactly(1)) // Second call to gpt->getAnswer
+            ->method('getAnswer')
                 ->with(
                     $this->callback(function ($context) {
                         $this->assertStringNotContainsString("【Web検索結果】", $context);

--- a/tests/WebSearchToolTest.php
+++ b/tests/WebSearchToolTest.php
@@ -40,20 +40,7 @@ class WebSearchToolTest extends TestCase
         // Test with both empty
         $this->assertSame(
             "Error: API key or CX ID is not configured for web search.",
-            WebSearchTool::search("test query", "", "")
-        );
-        // Test with null values as well, as properties might be null
-        $this->assertSame(
-            "Error: API key or CX ID is not configured for web search.",
-            WebSearchTool::search("test query", null, "fake_cx_id")
-        );
-        $this->assertSame(
-            "Error: API key or CX ID is not configured for web search.",
-            WebSearchTool::search("test query", "fake_api_key", null)
-        );
-        $this->assertSame(
-            "Error: API key or CX ID is not configured for web search.",
-            WebSearchTool::search("test query", null, null)
+            WebSearchTool::search("test query", "", "") // both apiKey and cx are ""
         );
     }
 

--- a/tests/WebSearchToolTest.php
+++ b/tests/WebSearchToolTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyApp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use MyApp\WebSearchTool; // Ensure this use statement is added
+
+class WebSearchToolTest extends TestCase
+{
+    public function testSearchReturnsPlaceholder(): void
+    {
+        $query = "test query";
+        $expectedResult = "Placeholder search results for query: " . $query;
+        $this->assertSame($expectedResult, WebSearchTool::search($query));
+    }
+}

--- a/tests/WebSearchToolTest.php
+++ b/tests/WebSearchToolTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace MyApp\Tests;
+// namespace MyApp\Tests;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use MyApp\WebSearchTool;
-use Google_Service_Customsearch;
-use Google_Service_Customsearch_Resource_Cse; // Resource class for cse->listCse
-use Google_Service_Customsearch_Search;       // Return type of listCse method
-use Google_Service_Customsearch_Result;       // Type for individual search items
+use Google\Service\CustomSearchAPI;
+use Google\Service\CustomSearchAPI\Resource\Cse; // Resource class for cse->listCse
+use Google\Service\CustomSearchAPI\Search;       // Return type of listCse method
+use Google\Service\CustomSearchAPI\Result;       // Type for individual search items
 use Exception; // For testing exception handling
 
 class WebSearchToolTest extends TestCase
@@ -24,10 +24,10 @@ class WebSearchToolTest extends TestCase
         parent::setUp();
 
         // Mock for Google_Service_Customsearch_Resource_Cse
-        $this->mockCseResource = $this->createMock(Google_Service_Customsearch_Resource_Cse::class);
+        $this->mockCseResource = $this->createMock(Cse::class);
 
         // Mock for Google_Service_Customsearch
-        $this->mockCustomSearchService = $this->createMock(Google_Service_Customsearch::class);
+        $this->mockCustomSearchService = $this->createMock(CustomSearchAPI::class);
         // The 'cse' property is public. We can assign our mock resource to it.
         $this->mockCustomSearchService->cse = $this->mockCseResource;
 
@@ -50,20 +50,20 @@ class WebSearchToolTest extends TestCase
         $numResults = 2;
 
         // Prepare mock search result items
-        $item1 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item1 = $this->createMock(Result::class);
         $item1->method('getTitle')->willReturn("Title 1");
         $item1->method('getSnippet')->willReturn("Snippet for item 1.");
 
-        $item2 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item2 = $this->createMock(Result::class);
         $item2->method('getTitle')->willReturn("Title 2");
         $item2->method('getSnippet')->willReturn("Snippet for item 2"); // No trailing period
 
-        $item3 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item3 = $this->createMock(Result::class);
         $item3->method('getTitle')->willReturn("Title 3 Only"); // No snippet
         $item3->method('getSnippet')->willReturn(null);
 
 
-        $mockSearchResults = $this->createMock(Google_Service_Customsearch_Search::class);
+        $mockSearchResults = $this->createMock(Search::class);
         $mockSearchResults->method('getItems')->willReturn([$item1, $item2, $item3]);
 
         $this->mockCseResource->expects($this->once())
@@ -90,11 +90,11 @@ class WebSearchToolTest extends TestCase
         $cx = "test_cx_less";
         $numResults = 3; // Request 3
 
-        $item1 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item1 = $this->createMock(Result::class);
         $item1->method('getTitle')->willReturn("Title A");
         $item1->method('getSnippet')->willReturn("Snippet A.");
 
-        $mockSearchResults = $this->createMock(Google_Service_Customsearch_Search::class);
+        $mockSearchResults = $this->createMock(Search::class);
         $mockSearchResults->method('getItems')->willReturn([$item1]); // API returns only 1
 
         $this->mockCseResource->expects($this->once())
@@ -116,7 +116,7 @@ class WebSearchToolTest extends TestCase
         $query = "no results query";
         $cx = "test_cx_no_results";
 
-        $mockSearchResults = $this->createMock(Google_Service_Customsearch_Search::class);
+        $mockSearchResults = $this->createMock(Search::class);
         $mockSearchResults->method('getItems')->willReturn([]); // Empty array of items
 
         $this->mockCseResource->expects($this->once())
@@ -134,11 +134,11 @@ class WebSearchToolTest extends TestCase
         $cx = "test_cx_empty_items";
 
         // Prepare mock search result items with no title or snippet
-        $item1 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item1 = $this->createMock(Result::class);
         $item1->method('getTitle')->willReturn(null);
         $item1->method('getSnippet')->willReturn(null);
 
-        $mockSearchResults = $this->createMock(Google_Service_Customsearch_Search::class);
+        $mockSearchResults = $this->createMock(Search::class);
         $mockSearchResults->method('getItems')->willReturn([$item1]);
 
         $this->mockCseResource->expects($this->once())

--- a/tests/WebSearchToolTest.php
+++ b/tests/WebSearchToolTest.php
@@ -5,14 +5,60 @@ declare(strict_types=1);
 namespace MyApp\Tests;
 
 use PHPUnit\Framework\TestCase;
-use MyApp\WebSearchTool; // Ensure this use statement is added
+use MyApp\WebSearchTool;
+// Google Client related use statements are removed for now as per the plan.
+// use Google_Client;
+// use Google_Service_Customsearch;
+// use Google_Service_Customsearch_Resource_Cse;
+// use Google_Service_Customsearch_Search;
+// use Google_Service_Customsearch_Result;
+// use Exception;
 
 class WebSearchToolTest extends TestCase
 {
-    public function testSearchReturnsPlaceholder(): void
+    // Old placeholder test removed.
+    // public function testSearchReturnsPlaceholder(): void
+    // {
+    //     $query = "test query";
+    //     // The old search method signature was different.
+    //     // $expectedResult = "Placeholder search results for query: " . $query; 
+    //     // $this->assertSame($expectedResult, WebSearchTool::search($query));
+    // }
+
+    public function testSearchReturnsErrorIfApiKeyOrCxIsMissing(): void
     {
-        $query = "test query";
-        $expectedResult = "Placeholder search results for query: " . $query;
-        $this->assertSame($expectedResult, WebSearchTool::search($query));
+        // Test with empty API key
+        $this->assertSame(
+            "Error: API key or CX ID is not configured for web search.",
+            WebSearchTool::search("test query", "", "fake_cx_id")
+        );
+        // Test with empty CX ID
+        $this->assertSame(
+            "Error: API key or CX ID is not configured for web search.",
+            WebSearchTool::search("test query", "fake_api_key", "")
+        );
+        // Test with both empty
+        $this->assertSame(
+            "Error: API key or CX ID is not configured for web search.",
+            WebSearchTool::search("test query", "", "")
+        );
+        // Test with null values as well, as properties might be null
+        $this->assertSame(
+            "Error: API key or CX ID is not configured for web search.",
+            WebSearchTool::search("test query", null, "fake_cx_id")
+        );
+        $this->assertSame(
+            "Error: API key or CX ID is not configured for web search.",
+            WebSearchTool::search("test query", "fake_api_key", null)
+        );
+        $this->assertSame(
+            "Error: API key or CX ID is not configured for web search.",
+            WebSearchTool::search("test query", null, null)
+        );
     }
+
+    // Further tests for successful API calls, empty results, and specific API exceptions
+    // would require refactoring WebSearchTool to allow mocking of the Google API client
+    // (e.g., by injecting the Google_Client instance).
+    // For now, these aspects would need to be tested manually or via integration tests.
 }

--- a/tests/WebSearchToolTest.php
+++ b/tests/WebSearchToolTest.php
@@ -5,47 +5,163 @@ declare(strict_types=1);
 namespace MyApp\Tests;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 use MyApp\WebSearchTool;
-// Google Client related use statements are removed for now as per the plan.
-// use Google_Client;
-// use Google_Service_Customsearch;
-// use Google_Service_Customsearch_Resource_Cse;
-// use Google_Service_Customsearch_Search;
-// use Google_Service_Customsearch_Result;
-// use Exception;
+use Google_Service_Customsearch;
+use Google_Service_Customsearch_Resource_Cse; // Resource class for cse->listCse
+use Google_Service_Customsearch_Search;       // Return type of listCse method
+use Google_Service_Customsearch_Result;       // Type for individual search items
+use Exception; // For testing exception handling
 
 class WebSearchToolTest extends TestCase
 {
-    // Old placeholder test removed.
-    // public function testSearchReturnsPlaceholder(): void
-    // {
-    //     $query = "test query";
-    //     // The old search method signature was different.
-    //     // $expectedResult = "Placeholder search results for query: " . $query; 
-    //     // $this->assertSame($expectedResult, WebSearchTool::search($query));
-    // }
+    private MockObject $mockCustomSearchService;
+    private MockObject $mockCseResource;
+    private WebSearchTool $webSearchTool;
 
-    public function testSearchReturnsErrorIfApiKeyOrCxIsMissing(): void
+    protected function setUp(): void
     {
-        // Test with empty API key
+        parent::setUp();
+
+        // Mock for Google_Service_Customsearch_Resource_Cse
+        $this->mockCseResource = $this->createMock(Google_Service_Customsearch_Resource_Cse::class);
+
+        // Mock for Google_Service_Customsearch
+        $this->mockCustomSearchService = $this->createMock(Google_Service_Customsearch::class);
+        // The 'cse' property is public. We can assign our mock resource to it.
+        $this->mockCustomSearchService->cse = $this->mockCseResource;
+
+        // Instantiate WebSearchTool with the mocked service
+        $this->webSearchTool = new WebSearchTool($this->mockCustomSearchService);
+    }
+
+    public function testSearchReturnsErrorIfCxIsMissing(): void
+    {
         $this->assertSame(
-            "Error: API key or CX ID is not configured for web search.",
-            WebSearchTool::search("test query", "", "fake_cx_id")
-        );
-        // Test with empty CX ID
-        $this->assertSame(
-            "Error: API key or CX ID is not configured for web search.",
-            WebSearchTool::search("test query", "fake_api_key", "")
-        );
-        // Test with both empty
-        $this->assertSame(
-            "Error: API key or CX ID is not configured for web search.",
-            WebSearchTool::search("test query", "", "") // both apiKey and cx are ""
+            "Error: Custom Search Engine ID (CX) is not provided for web search.",
+            $this->webSearchTool->search("test query", "") // CX is ""
         );
     }
 
-    // Further tests for successful API calls, empty results, and specific API exceptions
-    // would require refactoring WebSearchTool to allow mocking of the Google API client
-    // (e.g., by injecting the Google_Client instance).
-    // For now, these aspects would need to be tested manually or via integration tests.
+    public function testSearchSuccessful(): void
+    {
+        $query = "test query";
+        $cx = "test_cx";
+        $numResults = 2;
+
+        // Prepare mock search result items
+        $item1 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item1->method('getTitle')->willReturn("Title 1");
+        $item1->method('getSnippet')->willReturn("Snippet for item 1.");
+
+        $item2 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item2->method('getTitle')->willReturn("Title 2");
+        $item2->method('getSnippet')->willReturn("Snippet for item 2"); // No trailing period
+
+        $item3 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item3->method('getTitle')->willReturn("Title 3 Only"); // No snippet
+        $item3->method('getSnippet')->willReturn(null);
+
+
+        $mockSearchResults = $this->createMock(Google_Service_Customsearch_Search::class);
+        $mockSearchResults->method('getItems')->willReturn([$item1, $item2, $item3]);
+
+        $this->mockCseResource->expects($this->once())
+            ->method('listCse')
+            ->with(['q' => $query, 'cx' => $cx, 'num' => $numResults])
+            ->willReturn($mockSearchResults);
+
+        $expectedSummary = "Web Search Results:
+"
+                         . "- Title: Title 1. Snippet: Snippet for item 1.
+"
+                         . "- Title: Title 2. Snippet: Snippet for item 2.";
+                         // Item 3 should be sliced off by numResults = 2 if array_slice is used on summary,
+                         // or because we only request 2 items. The code gets $numResults items.
+                         // The code gets all items then array_slice. So item3 will be in $summary then sliced.
+
+        $actualSummary = $this->webSearchTool->search($query, $cx, $numResults);
+        $this->assertSame($expectedSummary, $actualSummary);
+    }
+    
+    public function testSearchSuccessfulWithFewerResultsThanRequested(): void
+    {
+        $query = "less results query";
+        $cx = "test_cx_less";
+        $numResults = 3; // Request 3
+
+        $item1 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item1->method('getTitle')->willReturn("Title A");
+        $item1->method('getSnippet')->willReturn("Snippet A.");
+
+        $mockSearchResults = $this->createMock(Google_Service_Customsearch_Search::class);
+        $mockSearchResults->method('getItems')->willReturn([$item1]); // API returns only 1
+
+        $this->mockCseResource->expects($this->once())
+            ->method('listCse')
+            ->with(['q' => $query, 'cx' => $cx, 'num' => $numResults])
+            ->willReturn($mockSearchResults);
+
+        $expectedSummary = "Web Search Results:
+"
+                         . "- Title: Title A. Snippet: Snippet A.";
+
+        $actualSummary = $this->webSearchTool->search($query, $cx, $numResults);
+        $this->assertSame($expectedSummary, $actualSummary);
+    }
+
+
+    public function testSearchReturnsNoResultsFound(): void
+    {
+        $query = "no results query";
+        $cx = "test_cx_no_results";
+
+        $mockSearchResults = $this->createMock(Google_Service_Customsearch_Search::class);
+        $mockSearchResults->method('getItems')->willReturn([]); // Empty array of items
+
+        $this->mockCseResource->expects($this->once())
+            ->method('listCse')
+            ->willReturn($mockSearchResults);
+
+        $expectedMessage = "No web search results found for: " . htmlspecialchars($query);
+        $actualMessage = $this->webSearchTool->search($query, $cx);
+        $this->assertSame($expectedMessage, $actualMessage);
+    }
+
+    public function testSearchReturnsCouldNotExtractUsefulInfo(): void
+    {
+        $query = "empty items query";
+        $cx = "test_cx_empty_items";
+
+        // Prepare mock search result items with no title or snippet
+        $item1 = $this->createMock(Google_Service_Customsearch_Result::class);
+        $item1->method('getTitle')->willReturn(null);
+        $item1->method('getSnippet')->willReturn(null);
+
+        $mockSearchResults = $this->createMock(Google_Service_Customsearch_Search::class);
+        $mockSearchResults->method('getItems')->willReturn([$item1]);
+
+        $this->mockCseResource->expects($this->once())
+            ->method('listCse')
+            ->willReturn($mockSearchResults);
+        
+        $expectedMessage = "Could not extract useful information from search results for: " . htmlspecialchars($query);
+        $actualMessage = $this->webSearchTool->search($query, $cx);
+        $this->assertSame($expectedMessage, $actualMessage);
+    }
+
+    public function testSearchHandlesApiException(): void
+    {
+        $query = "api exception query";
+        $cx = "test_cx_exception";
+        $exceptionMessage = "API communication failed";
+
+        $this->mockCseResource->expects($this->once())
+            ->method('listCse')
+            ->willThrowException(new Exception($exceptionMessage));
+
+        $expectedMessage = "Error performing web search. Details: " . $exceptionMessage;
+        $actualMessage = $this->webSearchTool->search($query, $cx);
+        $this->assertSame($expectedMessage, $actualMessage);
+    }
 }

--- a/tests/trigger_http_local.sh
+++ b/tests/trigger_http_local.sh
@@ -3,5 +3,5 @@ set -eu
 
 curl -X POST \
     -H "context-type: application:json" \
-    -d '{"events": [{"source": {"type": "group", "groupId": "TARGET_ID_TEST"}, "message": {"text": "今日はとても疲れた！"}, "replyToken": "REPLY_TOKEN"}]}' \
+    -d '{"events": [{"source": {"type": "group", "groupId": "TARGET_ID_TEST"}, "type":"message", "message": {"text": "今日の天気は？"}, "replyToken": "REPLY_TOKEN"}]}' \
     http://localhost:8080


### PR DESCRIPTION
Integrates a web search feature into the chatbot's response generation process.

Key changes:
- Added `WebSearchTool.php` with a placeholder for web search functionality.
- Modified `PersonalBot.php`:
    - Introduced `PROMPT_JUDGE_WEB_SEARCH` to enable GPT to decide if a web search is needed for a given user message.
    - Added `__shouldPerformWebSearch()` method to encapsulate this decision logic.
    - Updated `GPT_CONTEXT` and `__getContext()` to include web search results.
    - Modified `getAnswer()` to orchestrate the search: decide, call the search functionality, augment context, and generate the final answer.
- Added comprehensive unit tests:
    - `WebSearchToolTest.php` for the new search tool.
    - Updated `PersonalBotTest.php` to test `__shouldPerformWebSearch()`, `__getContext()` (with search results), and the `getAnswer()` method's new orchestration logic, including mocking of GPT responses.
- Created `LEARNINGS.md` to document the implementation process, challenges, and learnings from this task.

This feature allows the bot to (in principle) provide answers based on current information from the web, enhancing its knowledge beyond its training data. The actual web search mechanism in `WebSearchTool` is currently a placeholder.