### PR TITLE
Add debug logging for TimerTrigger instantiation

### DIFF
--- a/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
+++ b/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
@@ -55,7 +55,15 @@ class FirestoreBotRepository implements BotRepository
             $tData = $triggerDoc->data();
             // Assuming TimerTrigger for now, this would need to be more flexible
             if (isset($tData['event']) && $tData['event'] === 'timer') {
-                $trigger = new TimerTrigger($tData['date'], $tData['time'], $tData['request']);
+                // Added logging for date, time, and Consts::TIMEZONE
+                $dateForTrigger = $tData['date'] ?? null; // Use null coalescing for safety
+                $timeForTrigger = $tData['time'] ?? null; // Use null coalescing for safety
+
+                error_log("DEBUG TimerTrigger Instantiation: Input Date='{$dateForTrigger}', Input Time='{$timeForTrigger}'");
+                // Using fully qualified namespace for Consts to be safe.
+                error_log("DEBUG TimerTrigger Instantiation: Runtime Consts::TIMEZONE = " . \MyApp\Consts::TIMEZONE);
+
+                $trigger = new TimerTrigger($dateForTrigger, $timeForTrigger, $tData['request']);
                 $trigger->setId($triggerDoc->id()); // Use Firestore document ID as trigger ID
                 $triggers[$trigger->getId()] = $trigger;
             }


### PR DESCRIPTION
This commit adds logging statements to `FirestoreBotRepository.php` immediately before a `TimerTrigger` object is instantiated.

The following information will be logged:
- The `date` string being passed to the constructor.
- The `time` string being passed to the constructor.
- The runtime value of `\MyApp\Consts::TIMEZONE`.

This logging is intended to help diagnose an issue where timer triggers are reportedly firing 9 hours later than expected, by capturing the exact inputs and timezone constant value at the point of TimerTrigger creation.