### PR TITLE
I've updated the deploy-prod workflow to include event deployment.

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -28,13 +28,30 @@ jobs:
           workload_identity_provider: 'projects/1035100650942/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider'
           service_account: 'cloud-run-functions-deployer@nobu5-393106.iam.gserviceaccount.com'
 
-      - name: Deploy Cloud Functions
+      - name: Deploy Cloud Functions (http)
         uses: 'google-github-actions/deploy-cloud-functions@v3'
         timeout-minutes: 5
         with:
           name: ${{ env.FUNCTION_NAME }}
           runtime: php82
           entry_point: main
+          region: ${{ env.REGION }}
+          service_account: 'cloud-run-functions-deployer@nobu5-393106.iam.gserviceaccount.com'
+          source_dir: ./
+          max_instance_count: 1
+          secrets: |-
+            OPENAI_KEY_LINE_AI_BOT=projects/nobu5-393106/secrets/OPENAI_KEY_LINE_AI_BOT/versions/latest
+            LINE_TOKENS_N_TARGETS=projects/nobu5-393106/secrets/LINE_TOKENS_N_TARGETS/versions/latest
+            FIREBASE_CONFIG=projects/nobu5-393106/secrets/FIREBASE_CONFIG/versions/latest
+
+      - name: Deploy Cloud Functions (event)
+        uses: 'google-github-actions/deploy-cloud-functions@v3'
+        timeout-minutes: 5
+        with:
+          name: ${{ env.FUNCTION_NAME }}-trigger
+          runtime: php82
+          entry_point: trigger
+          event_trigger_pubsub_topic: ${{ env.FUNCTION_NAME }}-trigger
           region: ${{ env.REGION }}
           service_account: 'cloud-run-functions-deployer@nobu5-393106.iam.gserviceaccount.com'
           source_dir: ./


### PR DESCRIPTION
Here's a summary of the changes to the deploy-prod.yaml GitHub Actions workflow:
- I've renamed the existing Cloud Function deployment step to "Deploy Cloud Functions (http)" for better clarity.
- I've added a new deployment step called "Deploy Cloud Functions (event)".
- This new step is designed to deploy a function that's triggered by a Pub/Sub topic. The function name will have "-trigger" added to it, the entry point is "trigger", and it's set up with an event_trigger_pubsub_topic.
- This adjustment makes the production deployment process more consistent with the test deployment process, ensuring that both HTTP and event-triggered functions are deployed.