### PR TITLE
Refactor: Remove unused logger from TimerTrigger

### DIFF
--- a/src/Domain/Bot/Trigger/TimerTrigger.php
+++ b/src/Domain/Bot/Trigger/TimerTrigger.php
@@ -4,7 +4,6 @@ namespace MyApp\Domain\Bot\Trigger;
 
 use Carbon\Carbon;
 use MyApp\Consts;
-use yananob\MyTools\Logger;
 
 class TimerTrigger implements Trigger
 {
@@ -13,14 +12,10 @@ class TimerTrigger implements Trigger
     private string $time;
     private string $request;
     private string $actualDate;
-    private ?Logger $logger = null;
 
     public function __construct(string $date, string $time, string $request)
     {
-        $this->logger = new Logger('TimerTrigger');
-        $this->logger->log("TimerTrigger constructor called with date: '{$date}', time: '{$time}', request: '{$request}'");
         $carbonNow = new Carbon(timezone: new \DateTimeZone(Consts::TIMEZONE));
-        $this->logger->log("TimerTrigger constructor: carbonNow is " . $carbonNow->toString() . " with timezone " . $carbonNow->getTimezone()->getName());
 
         $this->date = $date;
         $this->request = $request;
@@ -55,7 +50,6 @@ class TimerTrigger implements Trigger
                 // No need to update $this->date here as it's already specific
                 break;
         }
-        $this->logger->log("TimerTrigger constructor: final this->time is '{$this->time}', final this->actualDate is '{$this->actualDate}'");
     }
 
     public function getId(): ?string
@@ -106,9 +100,7 @@ class TimerTrigger implements Trigger
 
     public function shouldRunNow(int $timerTriggeredByNMins): bool
     {
-        $this->logger->log("shouldRunNow: Checking trigger: ID {$this->id}, Date '{$this->date}', Time '{$this->time}', ActualDate '{$this->actualDate}'");
         $carbonNow = new Carbon(timezone: new \DateTimeZone(Consts::TIMEZONE));
-        $this->logger->log("shouldRunNow: carbonNow is " . $carbonNow->toString() . " with timezone " . $carbonNow->getTimezone()->getName());
 
         try {
             list($hour, $minute) = sscanf($this->time, "%d:%d");
@@ -136,22 +128,15 @@ class TimerTrigger implements Trigger
         
         if (!$triggerDateCarbon) {
              // Should not happen if logic above is correct
-            $this->logger->log("shouldRunNow: triggerDateCarbon is null, returning false.");
             return false;
         }
 
         $triggerDateTimeCarbon = $triggerDateCarbon->hour($hour)->minute($minute)->second(0);
-        if ($triggerDateTimeCarbon) {
-            $this->logger->log("shouldRunNow: triggerDateTimeCarbon is " . $triggerDateTimeCarbon->toString() . " with timezone " . $triggerDateTimeCarbon->getTimezone()->getName());
-        } else {
-            $this->logger->log("shouldRunNow: triggerDateTimeCarbon could not be determined.");
-        }
 
         // Calculate the difference in minutes.
         // A positive value means $triggerDateTimeCarbon is in the future or same minute.
         // A negative value means $triggerDateTimeCarbon is in the past.
         $diffMinutes = $carbonNow->diffInMinutes($triggerDateTimeCarbon, false);
-        $this->logger->log("shouldRunNow: diffMinutes is {$diffMinutes}");
 
         // Trigger if the event is scheduled for the current minute or any minute within the $timerTriggeredByNMins window in the future.
         // For example, if $timerTriggeredByNMins is 5:
@@ -160,7 +145,6 @@ class TimerTrigger implements Trigger
         // diffMinutes = 5 (5 minutes in future) -> false (because it's < $timerTriggeredByNMins)
         // diffMinutes = -1 (1 minute in past) -> false
         $result = $diffMinutes >= 0 && $diffMinutes < $timerTriggeredByNMins;
-        $this->logger->log("shouldRunNow: result is " . ($result ? 'true' : 'false'));
         return $result;
     }
 


### PR DESCRIPTION
The logger in `MyApp\Domain\Bot\Trigger\TimerTrigger` was an internal detail and is no longer required. This commit removes the logger declarations and all its usages from the class. No other functional code has been changed.