### PR TITLE
Fix: Improve freshness of web search results and cleanup WebSearchTool

### DIFF
--- a/src/WebSearchTool.php
+++ b/src/WebSearchTool.php
@@ -43,6 +43,9 @@ class WebSearchTool
             return "Error: Number of results must be positive.";
         }
 
+        // Modify the query to prefer recent information
+        $query .= " Prefer recent information from the last 12 months.";
+
         $params = [
             'model' => $this->openaiModel,
             'input' => $query,
@@ -50,28 +53,6 @@ class WebSearchTool
             'max_output_tokens' => 200 * $numResults, // Estimate, actual output structure will dictate usefulness
             'temperature' => 0.7,
         ];
-
-        // System prompt to guide the AI's response format
-        $systemPrompt = "You are a simulated web search engine. For the user's query, provide {$numResults} relevant findings.
-For each finding, strictly format it as:
-Title: [The title of the finding]
-Snippet: [A brief snippet of the finding]
-
-Separate each finding with exactly two newline characters. Do not include any other text before or after the findings.";
-
-        // User prompt with the actual query
-        $userPrompt = "Search the web for: " . htmlspecialchars($query);
-
-        // System prompt to guide the AI's response format
-        $systemPrompt = "You are a simulated web search engine. For the user's query, provide {$numResults} relevant findings.
-For each finding, strictly format it as:
-Title: [The title of the finding]
-Snippet: [A brief snippet of the finding]
-
-Separate each finding with exactly two newline characters. Do not include any other text before or after the findings.";
-
-        // User prompt with the actual query
-        $userPrompt = "Search the web for: " . htmlspecialchars($query);
 
         // System prompt to guide the AI's response format
         $systemPrompt = "You are a simulated web search engine. For the user's query, provide {$numResults} relevant findings.


### PR DESCRIPTION
I've modified `WebSearchTool.php` to address outdated web search results by appending a preference for recent information directly to the search query.

Changes include:
- Appended " Prefer recent information from the last 12 months." to the search query string. This aims to guide the AI to fetch more current results.
- Removed duplicated declarations of system and user prompts within the `search` method for better code clarity.

This change directly targets the issue of stale search data. The use of a modern model (`gpt-4o-mini`) was already in place, so prompt/query engineering is the next logical step.

Potential downside: This universal modification might affect queries intended to find historical information. Further refinement may be needed if this proves problematic.