### PR TITLE
Refactor: Update web search query for newer results and adapt tests

### DIFF
--- a/src/WebSearchTool.php
+++ b/src/WebSearchTool.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MyApp;
 
-use OpenAI\Client;
+use OpenAI\Contracts\ClientContract;
 use OpenAI\Responses\Responses\CreateResponse as ResponsesCreateResponse; // Updated use statement
 use OpenAI\Exceptions\ErrorException as OpenAIErrorException;
 use OpenAI\Exceptions\TransporterException as OpenAITransporterException;
@@ -12,16 +12,16 @@ use Exception; // Keep for general exceptions
 
 class WebSearchTool
 {
-    private Client $openaiClient;
+    private ClientContract $openaiClient;
     private string $openaiModel;
 
     /**
      * Constructor.
      *
-     * @param Client $openaiClient An initialized OpenAI API client.
+     * @param ClientContract $openaiClient An initialized OpenAI API client.
      * @param string $openaiModel The OpenAI model to use for searches (e.g., 'gpt-4o' or similar that supports responses()->create).
      */
-    public function __construct(Client $openaiClient, string $openaiModel)
+    public function __construct(ClientContract $openaiClient, string $openaiModel)
     {
         $this->openaiClient = $openaiClient;
         $this->openaiModel = $openaiModel;
@@ -44,7 +44,7 @@ class WebSearchTool
         }
 
         // Modify the query to prefer recent information
-        $query .= " Prefer recent information from the last 12 months.";
+        $query .= " 検索結果はできるだけ新しいものを使うようにしてください。";
 
         $params = [
             'model' => $this->openaiModel,


### PR DESCRIPTION
I've replaced the existing query suffix in the web search functionality with the Japanese phrase "検索結果はできるだけ新しいものを使うようにしてください。" to prioritize recent search results, as you requested.

A new test, testSearchQueryIncludesJapanesePhraseForRecentResults, has been added to WebSearchToolTest.php to specifically verify this modification.

Additionally, I refactored existing tests in WebSearchToolTest.php:
- Updated them to use OpenAI\Contracts\ClientContract and OpenAI\Contracts\Resources\ResponsesContract interfaces for mocking due to final class changes in the openai-php/client library.
- Adjusted mock API response creation (createMockApiResponse) and exception instantiation to match current library versions.
- Updated expected messages in several tests to account for the newly appended Japanese phrase in all search queries.

All tests in tests/WebSearchToolTest.php now pass with these changes.