### PR TITLE
ドメイン固有の例外の導入とバグ修正のリファクタリング

### DIFF
--- a/src/Domain/Exception/BotNotFoundException.php
+++ b/src/Domain/Exception/BotNotFoundException.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Domain\Exception;
+
+class BotNotFoundException extends DomainException
+{
+}

--- a/src/Domain/Exception/DomainException.php
+++ b/src/Domain/Exception/DomainException.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Domain\Exception;
+
+abstract class DomainException extends \Exception
+{
+}

--- a/src/Domain/Exception/InvalidWebhookEventException.php
+++ b/src/Domain/Exception/InvalidWebhookEventException.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Domain\Exception;
+
+class InvalidWebhookEventException extends DomainException
+{
+}

--- a/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
+++ b/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
@@ -10,6 +10,7 @@ use MyApp\Domain\Bot\Bot;
 use MyApp\Domain\Bot\BotRepository;
 use MyApp\Domain\Bot\Trigger\TimerTrigger;
 use MyApp\Domain\Bot\Trigger\Trigger;
+use MyApp\Domain\Exception\BotNotFoundException;
 
 class FirestoreBotRepository implements BotRepository
 {
@@ -95,7 +96,7 @@ class FirestoreBotRepository implements BotRepository
         $configSnapshot = $defaultBotCollection->document('config')->snapshot();
 
         if (!$configSnapshot->exists()) {
-            throw new \RuntimeException("Default bot configuration does not exist.");
+            throw new BotNotFoundException("Default bot configuration with ID 'default' not found.");
         }
 
         // The default bot does not have a further default config, so pass null.

--- a/src/LineWebhookMessage.php
+++ b/src/LineWebhookMessage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MyApp;
 
+use MyApp\Domain\Exception\InvalidWebhookEventException;
+
 // TODO: MyToolsに移す
 class LineWebhookMessage
 {
@@ -47,7 +49,7 @@ class LineWebhookMessage
         } else if ($type === 'room') {
             return $this->event->source->roomId;
         } else {
-            throw new \Exception("Unknown type :" + $type);
+            throw new InvalidWebhookEventException("Unknown type :" . $type);
         }
     }
 

--- a/tests/FirestoreBotRepositoryTest.php
+++ b/tests/FirestoreBotRepositoryTest.php
@@ -7,6 +7,7 @@ namespace MyApp\Tests\Infrastructure\Persistence\Firestore;
 use MyApp\Infrastructure\Persistence\Firestore\FirestoreBotRepository;
 use MyApp\Domain\Bot\Bot;
 use MyApp\Domain\Bot\Trigger\TimerTrigger;
+use MyApp\Domain\Exception\BotNotFoundException;
 use Google\Cloud\Firestore\FirestoreClient;
 use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\DocumentReference;
@@ -72,11 +73,25 @@ final class FirestoreBotRepositoryTest extends TestCase
         $this->assertEquals($botId, $bot->getId());
     }
 
+    public function test_findDefaultThrowsExceptionWhenNotFound(): void
+    {
+        $botId = 'default';
+        [$botCollMock, $configDocMock, $snapshotMock] = $this->createBotMocks();
+
+        $this->documentRootMock->method('collection')->with($botId)->willReturn($botCollMock);
+        $snapshotMock->method('exists')->willReturn(false);
+
+        $this->expectException(BotNotFoundException::class);
+        $this->expectExceptionMessage("Default bot configuration with ID 'default' not found.");
+
+        $this->repository->findDefault();
+    }
+
     public function test_findByIdが成功する(): void
     {
         $botId = 'test-bot';
 
-        $this->documentRootMock->method('collection')->willReturnCallback(function($id) use ($botId) {
+        $this->documentRootMock->method('collection')->willReturnCallback(function($id) {
             [$botCollMock, $configDocMock, $snapshotMock] = $this->createBotMocks();
             $snapshotMock->method('exists')->willReturn(true);
             if ($id === 'default') {

--- a/tests/LineWebhookMessageTest.php
+++ b/tests/LineWebhookMessageTest.php
@@ -6,6 +6,7 @@ namespace MyApp\Tests; // 名前空間を追加
 
 use MyApp\Consts;
 use MyApp\LineWebhookMessage;
+use MyApp\Domain\Exception\InvalidWebhookEventException;
 use PHPUnit\Framework\TestCase; // TestCaseをuse
 
 final class LineWebhookMessageTest extends TestCase // TestCaseの完全修飾名を使用 (useしたのでこれでOK)
@@ -134,5 +135,26 @@ EOM;
     public function test_リプライトークンを取得する(): void
     {
         $this->assertSame("b3c26b13dfc74f6387c8bea36965e27c", $this->groupMessage->getReplyToken());
+    }
+
+    public function test_getTargetIdThrowsExceptionForUnknownType(): void
+    {
+        $invalidJson = <<<EOM
+{
+    "events": [
+        {
+            "type": "message",
+            "source": {
+                "type": "unknown",
+                "id": "123"
+            }
+        }
+    ]
+}
+EOM;
+        $message = new LineWebhookMessage($invalidJson);
+        $this->expectException(InvalidWebhookEventException::class);
+        $this->expectExceptionMessage("Unknown type :unknown");
+        $message->getTargetId();
     }
 }


### PR DESCRIPTION
ドメイン固有の例外クラスを導入し、エラーハンドリングの精度を高めるとともに、`LineWebhookMessage` で発見された文字列結合のバグを修正しました。

主な変更点：
1. `src/Domain/Exception` ディレクトリを新設し、`DomainException` (abstract), `BotNotFoundException`, `InvalidWebhookEventException` を追加。
2. `FirestoreBotRepository::findDefault` において、デフォルト設定が見つからない場合に `BotNotFoundException` を投げるよう変更。
3. `LineWebhookMessage::getTargetId` において、文字列結合に `+` が使われていたバグを `.` に修正し、例外を `InvalidWebhookEventException` に変更。
4. それぞれの例外が正しく投げられることを検証するユニットテストを追加。
5. テストコード内の未使用変数による PHPStan の警告を修正。

---
*PR created automatically by Jules for task [1292512821288676341](https://jules.google.com/task/1292512821288676341) started by @yananob*