### PR TITLE
Implement Domain-Specific Exceptions and Improve Error Handling

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,6 +16,9 @@ use MyApp\Consts;
 use MyApp\Command;
 use MyApp\LineWebhookMessage;
 use MyApp\Application\ChatApplicationService;
+use MyApp\Domain\Exception\BotNotFoundException;
+use MyApp\Domain\Exception\InvalidWebhookEventException;
+use MyApp\Domain\Exception\DomainException;
 use MyApp\Domain\Bot\Service\CommandAndTriggerService;
 use MyApp\Infrastructure\Persistence\Firestore\FirestoreBotRepository;
 use MyApp\Infrastructure\Persistence\Firestore\FirestoreConversationRepository;
@@ -48,15 +51,22 @@ function main_http(ServerRequestInterface $request): ResponseInterface
     $commandAndTriggerService = new CommandAndTriggerService(); // Assumes Gpt config path is correct in its constructor
 
     try {
+        $targetId = $webhookMessage->getTargetId();
         $chatService = new ChatApplicationService(
-            $webhookMessage->getTargetId(),
+            $targetId,
             $botRepository,
             $conversationRepository,
             // $isLocal
         );
-    } catch (\RuntimeException $e) {
-        $logger->log("Failed to initialize ChatApplicationService for target {$webhookMessage->getTargetId()}: " . $e->getMessage());
+    } catch (InvalidWebhookEventException $e) {
+        $logger->log("Invalid webhook event: " . $e->getMessage());
+        return new Response(400, ['Content-Type' => 'application/json'], '{"result": "error", "message": "Invalid webhook event."}');
+    } catch (BotNotFoundException $e) {
+        $logger->log("Bot initialization failed: " . $e->getMessage());
         return new Response(500, ['Content-Type' => 'application/json'], '{"result": "error", "message": "Bot initialization failed."}');
+    } catch (\RuntimeException $e) {
+        $logger->log("Runtime error during initialization: " . $e->getMessage());
+        return new Response(500, ['Content-Type' => 'application/json'], '{"result": "error", "message": "Internal server error."}');
     }
 
     $line = __getLineInstance();
@@ -172,8 +182,11 @@ function main_event(CloudEventInterface $event): void
                     $conversationRepository, // Pass the already instantiated repository
                     // $isLocal
                 );
+            } catch (DomainException $e) {
+                $logger->log("TRIGGER: Domain error for user {$botUser->getId()}: " . $e->getMessage());
+                continue; // Skip to next botUser
             } catch (\RuntimeException $e) {
-                $logger->log("TRIGGER: Failed to initialize ChatApplicationService for user {$botUser->getId()}: " . $e->getMessage());
+                $logger->log("TRIGGER: Runtime error for user {$botUser->getId()}: " . $e->getMessage());
                 continue; // Skip to next botUser
             }
 

--- a/src/Domain/Exception/BotNotFoundException.php
+++ b/src/Domain/Exception/BotNotFoundException.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Domain\Exception;
+
+class BotNotFoundException extends DomainException {}

--- a/src/Domain/Exception/DomainException.php
+++ b/src/Domain/Exception/DomainException.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Domain\Exception;
+
+abstract class DomainException extends \Exception {}

--- a/src/Domain/Exception/InvalidWebhookEventException.php
+++ b/src/Domain/Exception/InvalidWebhookEventException.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Domain\Exception;
+
+class InvalidWebhookEventException extends DomainException {}

--- a/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
+++ b/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
@@ -10,6 +10,7 @@ use MyApp\Domain\Bot\Bot;
 use MyApp\Domain\Bot\BotRepository;
 use MyApp\Domain\Bot\Trigger\TimerTrigger;
 use MyApp\Domain\Bot\Trigger\Trigger;
+use MyApp\Domain\Exception\BotNotFoundException;
 
 class FirestoreBotRepository implements BotRepository
 {
@@ -95,7 +96,7 @@ class FirestoreBotRepository implements BotRepository
         $configSnapshot = $defaultBotCollection->document('config')->snapshot();
 
         if (!$configSnapshot->exists()) {
-            throw new \RuntimeException("Default bot configuration does not exist.");
+            throw new BotNotFoundException("Default bot configuration does not exist.");
         }
 
         // The default bot does not have a further default config, so pass null.

--- a/src/LineWebhookMessage.php
+++ b/src/LineWebhookMessage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace MyApp;
 
+use MyApp\Domain\Exception\InvalidWebhookEventException;
+
 // TODO: MyToolsに移す
 class LineWebhookMessage
 {
@@ -47,7 +49,7 @@ class LineWebhookMessage
         } else if ($type === 'room') {
             return $this->event->source->roomId;
         } else {
-            throw new \Exception("Unknown type :" + $type);
+            throw new InvalidWebhookEventException("Unknown type :" . $type);
         }
     }
 

--- a/tests/FirestoreBotRepositoryTest.php
+++ b/tests/FirestoreBotRepositoryTest.php
@@ -6,6 +6,7 @@ namespace MyApp\Tests\Infrastructure\Persistence\Firestore;
 
 use MyApp\Infrastructure\Persistence\Firestore\FirestoreBotRepository;
 use MyApp\Domain\Bot\Bot;
+use MyApp\Domain\Exception\BotNotFoundException;
 use MyApp\Domain\Bot\Trigger\TimerTrigger;
 use Google\Cloud\Firestore\FirestoreClient;
 use Google\Cloud\Firestore\CollectionReference;
@@ -92,6 +93,18 @@ final class FirestoreBotRepositoryTest extends TestCase
         $this->assertInstanceOf(Bot::class, $bot);
         $this->assertEquals($botId, $bot->getId());
         $this->assertEquals(['test-char'], $bot->getBotCharacteristics());
+    }
+
+    public function test_findDefaultが失敗したときに例外を投げる(): void
+    {
+        $botId = 'default';
+        [$botCollMock, $configDocMock, $snapshotMock] = $this->createBotMocks();
+
+        $this->documentRootMock->method('collection')->with($botId)->willReturn($botCollMock);
+        $snapshotMock->method('exists')->willReturn(false);
+
+        $this->expectException(BotNotFoundException::class);
+        $this->repository->findDefault();
     }
 
     public function test_saveが成功する(): void

--- a/tests/LineWebhookMessageTest.php
+++ b/tests/LineWebhookMessageTest.php
@@ -6,6 +6,7 @@ namespace MyApp\Tests; // 名前空間を追加
 
 use MyApp\Consts;
 use MyApp\LineWebhookMessage;
+use MyApp\Domain\Exception\InvalidWebhookEventException;
 use PHPUnit\Framework\TestCase; // TestCaseをuse
 
 final class LineWebhookMessageTest extends TestCase // TestCaseの完全修飾名を使用 (useしたのでこれでOK)
@@ -134,5 +135,25 @@ EOM;
     public function test_リプライトークンを取得する(): void
     {
         $this->assertSame("b3c26b13dfc74f6387c8bea36965e27c", $this->groupMessage->getReplyToken());
+    }
+
+    public function test_不明なタイプの場合は例外を投げる(): void
+    {
+        $invalidJson = <<<EOM
+{
+    "events": [
+        {
+            "type": "message",
+            "source": {
+                "type": "unknown"
+            }
+        }
+    ]
+}
+EOM;
+        $message = new LineWebhookMessage($invalidJson);
+        $this->expectException(InvalidWebhookEventException::class);
+        $this->expectExceptionMessage("Unknown type :unknown");
+        $message->getTargetId();
     }
 }


### PR DESCRIPTION
Identified a maintainability issue where generic exceptions were used for domain-specific errors. Implemented a domain exception hierarchy and updated the repository and webhook message parsing logic to use them. This allows for more precise error handling at the application entry points. Also fixed a bug in LineWebhookMessage where string concatenation was using `+` instead of `.`. verified changes with PHPUnit and PHPStan.

---
*PR created automatically by Jules for task [17311793462822098210](https://jules.google.com/task/17311793462822098210) started by @yananob*