### PR TITLE
Add domain unit tests and improve Bot entity coverage

### DIFF
--- a/tests/Domain/Bot/BotTest.php
+++ b/tests/Domain/Bot/BotTest.php
@@ -36,6 +36,10 @@ final class BotTest extends TestCase
         $defaultBot->setBotCharacteristics(['デフォルト特性']);
         $botWithDefault = new Bot("botWithDef", $defaultBot);
         $this->assertEquals(['デフォルト特性'], $botWithDefault->getBotCharacteristics()->toArray());
+
+        // 個別設定がある場合はそちらが優先される
+        $botWithDefault->setBotCharacteristics(['個別特性']);
+        $this->assertEquals(['個別特性'], $botWithDefault->getBotCharacteristics()->toArray());
     }
 
     public function test_人間の特性を設定および取得する(): void
@@ -60,6 +64,11 @@ final class BotTest extends TestCase
 
         $this->assertTrue($botWithDefault->hasHumanCharacteristics());
         $this->assertEquals(['デフォルト人間特性'], $botWithDefault->getHumanCharacteristics()->toArray());
+
+        // 個別設定が空でもデフォルトがあればTrue
+        $botWithDefault->setHumanCharacteristics([]);
+        $this->assertTrue($botWithDefault->hasHumanCharacteristics());
+        $this->assertEquals(['デフォルト人間特性'], $botWithDefault->getHumanCharacteristics()->toArray());
     }
 
     public function test_設定リクエストを設定および取得する(): void
@@ -69,11 +78,43 @@ final class BotTest extends TestCase
         $this->assertEquals($reqs, $this->bot->getConfigRequests(true, false)->toArray());
     }
 
+    public function test_設定リクエストがデフォルトとマージされることを確認する(): void
+    {
+        $defaultBot = new Bot("defaultBotId");
+        $defaultBot->setConfigRequests(['デフォルトリクエスト']);
+
+        $bot = new Bot("myBot", $defaultBot);
+        $bot->setConfigRequests(['個別リクエスト']);
+
+        $allRequests = $bot->getConfigRequests(true, true);
+        $this->assertEquals(['デフォルトリクエスト', '個別リクエスト'], $allRequests->toArray());
+
+        // 個別のみ
+        $personalOnly = $bot->getConfigRequests(true, false);
+        $this->assertEquals(['個別リクエスト'], $personalOnly->toArray());
+
+        // デフォルトのみ
+        $defaultOnly = $bot->getConfigRequests(false, true);
+        $this->assertEquals(['デフォルトリクエスト'], $defaultOnly->toArray());
+    }
+
     public function test_LINEターゲットを設定および取得する(): void
     {
         $target = "test_target_123";
         $this->bot->setLineTarget($target);
         $this->assertEquals($target, $this->bot->getLineTarget());
+    }
+
+    public function test_LINEターゲットが設定されていない場合にデフォルトから取得する(): void
+    {
+        $defaultBot = new Bot("defaultBotId");
+        $defaultBot->setLineTarget("default_target");
+
+        $bot = new Bot("myBot", $defaultBot);
+        $this->assertEquals("default_target", $bot->getLineTarget());
+
+        $bot->setLineTarget("personal_target");
+        $this->assertEquals("personal_target", $bot->getLineTarget());
     }
 
     public function test_トリガーを追加および取得する(): void

--- a/tests/Domain/Bot/ValueObject/BotPersonalityConfigTest.php
+++ b/tests/Domain/Bot/ValueObject/BotPersonalityConfigTest.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Tests\Domain\Bot\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+use MyApp\Domain\Bot\ValueObject\BotPersonalityConfig;
+use MyApp\Domain\Bot\ValueObject\StringList;
+
+class BotPersonalityConfigTest extends TestCase
+{
+    public function test_getters_return_correct_instances(): void
+    {
+        $botChars = new StringList(['bot']);
+        $humanChars = new StringList(['human']);
+        $config = new BotPersonalityConfig($botChars, $humanChars);
+
+        $this->assertSame($botChars, $config->getBotCharacteristics());
+        $this->assertSame($humanChars, $config->getHumanCharacteristics());
+    }
+
+    public function test_isEmpty_returns_true_if_both_lists_are_empty(): void
+    {
+        $config = new BotPersonalityConfig(new StringList([]), new StringList([]));
+        $this->assertTrue($config->isEmpty());
+    }
+
+    public function test_isEmpty_returns_false_if_bot_chars_not_empty(): void
+    {
+        $config = new BotPersonalityConfig(new StringList(['bot']), new StringList([]));
+        $this->assertFalse($config->isEmpty());
+    }
+
+    public function test_isEmpty_returns_false_if_human_chars_not_empty(): void
+    {
+        $config = new BotPersonalityConfig(new StringList([]), new StringList(['human']));
+        $this->assertFalse($config->isEmpty());
+    }
+}

--- a/tests/Domain/Bot/ValueObject/StringListTest.php
+++ b/tests/Domain/Bot/ValueObject/StringListTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Tests\Domain\Bot\ValueObject;
+
+use PHPUnit\Framework\TestCase;
+use MyApp\Domain\Bot\ValueObject\StringList;
+
+class StringListTest extends TestCase
+{
+    public function test_isEmpty_returns_true_for_empty_array(): void
+    {
+        $list = new StringList([]);
+        $this->assertTrue($list->isEmpty());
+    }
+
+    public function test_isEmpty_returns_false_for_non_empty_array(): void
+    {
+        $list = new StringList(['a']);
+        $this->assertFalse($list->isEmpty());
+    }
+
+    public function test_toArray_returns_original_values(): void
+    {
+        $values = ['a', 'b', 'c'];
+        $list = new StringList($values);
+        $this->assertSame($values, $list->toArray());
+    }
+
+    public function test_format_returns_empty_string_for_empty_list(): void
+    {
+        $list = new StringList([]);
+        $this->assertSame("", $list->format());
+    }
+
+    public function test_format_returns_formatted_string_for_non_empty_list(): void
+    {
+        $list = new StringList(['item1', 'item2']);
+        $this->assertSame("・item1\n・item2", $list->format());
+    }
+
+    public function test_merge_returns_new_instance_with_combined_values(): void
+    {
+        $list1 = new StringList(['a']);
+        $list2 = new StringList(['b']);
+        $merged = $list1->merge($list2);
+
+        $this->assertNotSame($list1, $merged);
+        $this->assertNotSame($list2, $merged);
+        $this->assertSame(['a', 'b'], $merged->toArray());
+    }
+}

--- a/tests/Domain/Conversation/ConversationTest.php
+++ b/tests/Domain/Conversation/ConversationTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Tests\Domain\Conversation;
+
+use PHPUnit\Framework\TestCase;
+use MyApp\Domain\Conversation\Conversation;
+use DateTimeImmutable;
+
+class ConversationTest extends TestCase
+{
+    public function test_constructor_and_getters(): void
+    {
+        $botId = 'bot-123';
+        $speaker = 'human';
+        $content = 'Hello world';
+        $createdAt = new DateTimeImmutable('2025-01-01 10:00:00');
+        $id = 'conv-456';
+
+        $conversation = new Conversation($botId, $speaker, $content, $createdAt, $id);
+
+        $this->assertSame($botId, $conversation->getBotId());
+        $this->assertSame($speaker, $conversation->getSpeaker());
+        $this->assertSame($content, $conversation->getContent());
+        $this->assertSame($createdAt, $conversation->getCreatedAt());
+        $this->assertSame($id, $conversation->getId());
+    }
+
+    public function test_setId_updates_id(): void
+    {
+        $conversation = new Conversation('bot', 'human', 'msg');
+        $this->assertNull($conversation->getId());
+
+        $conversation->setId('new-id');
+        $this->assertSame('new-id', $conversation->getId());
+    }
+
+    public function test_constructor_default_values(): void
+    {
+        $conversation = new Conversation('bot', 'bot', 'answer');
+
+        $this->assertNull($conversation->getId());
+        $this->assertInstanceOf(DateTimeImmutable::class, $conversation->getCreatedAt());
+        // createdAt should be recent
+        $this->assertTrue((time() - $conversation->getCreatedAt()->getTimestamp()) < 5);
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for domain Value Objects (StringList, BotPersonalityConfig) and the Conversation entity. It also enhances the Bot entity tests to specifically verify fallback logic to the default bot and configuration merging behavior.

---
*PR created automatically by Jules for task [16414859432435545975](https://jules.google.com/task/16414859432435545975) started by @yananob*