### PR TITLE
Refactor TimerTrigger and Extract TriggerSchedule Value Object

### DIFF
--- a/src/Domain/Bot/Trigger/TimerTrigger.php
+++ b/src/Domain/Bot/Trigger/TimerTrigger.php
@@ -2,60 +2,23 @@
 
 namespace MyApp\Domain\Bot\Trigger;
 
-use Carbon\Carbon;
-use MyApp\Consts;
+use MyApp\Domain\Bot\ValueObject\TriggerSchedule;
 
 class TimerTrigger implements Trigger
 {
     private ?string $id = null;
-    private string $date;
-    private string $time;
+    private TriggerSchedule $schedule;
     private string $request;
-    private string $actualDate;
 
     /**
-     * Notes: このメソッド内でnew Carbon()をしているので、Carbon::setTestNow()など日付を調整する場合は、コンストラクタ以前に実行すること
      * @param string $date タイマー実行日（JST）
      * @param string $time タイマー実行時間（JST）
      * @param string $request タイマー実行時のリクエスト内容
      */
     public function __construct(string $date, string $time, string $request)
     {
-        $carbonNow = new Carbon(timezone: new \DateTimeZone(Consts::TIMEZONE));
-
-        $this->date = $date;
+        $this->schedule = new TriggerSchedule($date, $time);
         $this->request = $request;
-
-        // Handle time
-        if (preg_match('/^now \+(\d+) mins$/', $time, $matches)) {
-            $this->time = $carbonNow->copy()->addMinutes((int)$matches[1])->format('H:i');
-        } else {
-            $this->time = $time;
-        }
-
-        // Handle date
-        switch ($this->date) {
-            case 'everyday':
-                $this->actualDate = 'everyday'; // Special case, doesn't resolve to a specific date
-                break;
-            case 'today':
-                $this->actualDate = $carbonNow->copy()->format('Y/m/d');
-                // $this->date = $this->actualDate;
-                break;
-            case 'tomorrow':
-                $this->actualDate = $carbonNow->copy()->addDay()->format('Y/m/d');
-                // $this->date = $this->actualDate;
-                break;
-            case 'day after tomorrow':
-                $this->actualDate = $carbonNow->copy()->addDays(2)->format('Y/m/d');
-                // $this->date = $this->actualDate;
-                break;
-            default:
-                // Assumes a specific date string like YYYY/MM/DD or YYYY-MM-DD
-                $this->actualDate = Carbon::parse($this->date, new \DateTimeZone(Consts::TIMEZONE))->format('Y/m/d');
-                // No need to update $this->date here as it's already specific
-                break;
-        }
     }
 
     public function getId(): ?string
@@ -80,74 +43,42 @@ class TimerTrigger implements Trigger
 
     public function toArray(): array
     {
+        // IMPORTANT: We store the resolved date and time to ensure that
+        // relative dates (like 'tomorrow') are fixed upon persistence.
         return [
             'id' => $this->id,
             'event' => $this->getEvent(),
-            'date' => $this->date,
-            'time' => $this->time,
+            'date' => $this->schedule->getResolvedDate(),
+            'time' => $this->schedule->getResolvedTime(),
             'request' => $this->request,
         ];
     }
 
     public function getDate(): string
     {
-        return $this->date;
+        return $this->schedule->getOriginalDate();
     }
 
     public function getTime(): string
     {
-        return $this->time;
+        // For 'now +X mins', the original code returned the resolved time.
+        return $this->schedule->getResolvedTime();
     }
 
     public function getActualDate(): string
     {
-        return $this->actualDate;
+        return $this->schedule->getResolvedDate();
     }
 
     public function shouldRunNow(int $timerTriggeredByNMins): bool
     {
-        $carbonNow = new Carbon(timezone: new \DateTimeZone(Consts::TIMEZONE));
-
-        try {
-            list($hour, $minute) = sscanf($this->time, "%d:%d");
-            if (is_null($hour) || is_null($minute)) {
-                return false;
-            }
-        } catch (\Exception $e) {
-            return false;
-        }
-
-        $triggerDateCarbon = null;
-        try {
-            if ($this->actualDate === 'everyday') {
-                $triggerDateCarbon = $carbonNow->copy()->startOfDay();
-            } else {
-                $triggerDateCarbon = Carbon::parse($this->actualDate, new \DateTimeZone(Consts::TIMEZONE))->startOfDay();
-            }
-        } catch (\Exception $e) {
-            return false;
-        }
-        
-        if (!$triggerDateCarbon) {
-            return false;
-        }
-
-        $triggerDateTimeCarbon = $triggerDateCarbon->hour($hour)->minute($minute)->second(0);
-
-        // Calculate current time slot
-        $slotMinuteValue = floor($carbonNow->minute / $timerTriggeredByNMins) * $timerTriggeredByNMins;
-        $slotStartTime = $carbonNow->copy()->minute((int)$slotMinuteValue)->second(0)->microsecond(0);
-        $slotEndTime = $slotStartTime->copy()->addMinutes($timerTriggeredByNMins);
-
-        // Timer should run if its scheduled time is within the current slot
-        $result = $triggerDateTimeCarbon->gte($slotStartTime) &&
-                  $triggerDateTimeCarbon->lt($slotEndTime);
-
-        return $result;
+        return $this->schedule->shouldRunNow($timerTriggeredByNMins);
     }
 
     public function __toString(): string
     {
-        return "{$this->date} {$this->time} {$this->request}";
+        // Maintains consistency with original behavior where time was resolved for 'now +X mins'
+        // but date remained as the original input (e.g., 'today', 'tomorrow', or '2023-12-25').
+        return "{$this->schedule->getOriginalDate()} {$this->schedule->getResolvedTime()} {$this->request}";
     }
 }

--- a/src/Domain/Bot/ValueObject/TriggerSchedule.php
+++ b/src/Domain/Bot/ValueObject/TriggerSchedule.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace MyApp\Domain\Bot\ValueObject;
+
+use Carbon\Carbon;
+use MyApp\Consts;
+
+/**
+ * Handles the scheduling logic for a trigger, including relative date/time resolution.
+ */
+class TriggerSchedule
+{
+    private string $originalDate;
+    private string $originalTime;
+    private string $resolvedDate;
+    private string $resolvedTime;
+
+    public function __construct(string $date, string $time)
+    {
+        $carbonNow = new Carbon(timezone: new \DateTimeZone(Consts::TIMEZONE));
+
+        $this->originalDate = $date;
+        $this->originalTime = $time;
+
+        // Resolve relative time (e.g., "now +10 mins")
+        if (preg_match('/^now \+(\d+) mins$/', $time, $matches)) {
+            $this->resolvedTime = $carbonNow->copy()->addMinutes((int)$matches[1])->format('H:i');
+        } else {
+            $this->resolvedTime = $time;
+        }
+
+        // Resolve relative date (e.g., "today", "tomorrow")
+        switch ($date) {
+            case 'everyday':
+                $this->resolvedDate = 'everyday';
+                break;
+            case 'today':
+                $this->resolvedDate = $carbonNow->copy()->format('Y/m/d');
+                break;
+            case 'tomorrow':
+                $this->resolvedDate = $carbonNow->copy()->addDay()->format('Y/m/d');
+                break;
+            case 'day after tomorrow':
+                $this->resolvedDate = $carbonNow->copy()->addDays(2)->format('Y/m/d');
+                break;
+            default:
+                // Assumes a specific date string or already resolved date
+                try {
+                    // Try parsing and normalization
+                    $this->resolvedDate = Carbon::parse($date, new \DateTimeZone(Consts::TIMEZONE))->format('Y/m/d');
+                } catch (\Exception $e) {
+                    // Fallback to original if parsing fails
+                    $this->resolvedDate = $date;
+                }
+                break;
+        }
+    }
+
+    public function getResolvedDate(): string
+    {
+        return $this->resolvedDate;
+    }
+
+    public function getResolvedTime(): string
+    {
+        return $this->resolvedTime;
+    }
+
+    public function getOriginalDate(): string
+    {
+        return $this->originalDate;
+    }
+
+    public function getOriginalTime(): string
+    {
+        return $this->originalTime;
+    }
+
+    public function shouldRunNow(int $timerTriggeredByNMins): bool
+    {
+        $carbonNow = new Carbon(timezone: new \DateTimeZone(Consts::TIMEZONE));
+
+        try {
+            list($hour, $minute) = sscanf($this->resolvedTime, "%d:%d");
+            if (is_null($hour) || is_null($minute)) {
+                return false;
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        try {
+            if ($this->resolvedDate === 'everyday') {
+                $triggerDateCarbon = $carbonNow->copy()->startOfDay();
+            } else {
+                // Try to parse resolvedDate
+                $triggerDateCarbon = Carbon::parse($this->resolvedDate, new \DateTimeZone(Consts::TIMEZONE))->startOfDay();
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        if (!$triggerDateCarbon) {
+            return false;
+        }
+
+        $triggerDateTimeCarbon = $triggerDateCarbon->hour($hour)->minute($minute)->second(0);
+
+        // Calculate current time slot
+        $slotMinuteValue = floor($carbonNow->minute / $timerTriggeredByNMins) * $timerTriggeredByNMins;
+        $slotStartTime = $carbonNow->copy()->minute((int)$slotMinuteValue)->second(0)->microsecond(0);
+        $slotEndTime = $slotStartTime->copy()->addMinutes($timerTriggeredByNMins);
+
+        // Timer should run if its scheduled time is within the current slot
+        return $triggerDateTimeCarbon->gte($slotStartTime) && $triggerDateTimeCarbon->lt($slotEndTime);
+    }
+
+    public function __toString(): string
+    {
+        return "{$this->resolvedDate} {$this->resolvedTime}";
+    }
+}

--- a/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
+++ b/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
@@ -56,9 +56,10 @@ class FirestoreBotRepository implements BotRepository
             $tData = $triggerDoc->data();
             // Assuming TimerTrigger for now, this would need to be more flexible
             if (isset($tData['event']) && $tData['event'] === 'timer') {
-                $dateForTrigger = $tData['date'] ?? null; // Use null coalescing for safety
-                $timeForTrigger = $tData['time'] ?? null; // Use null coalescing for safety
-                $trigger = new TimerTrigger($dateForTrigger, $timeForTrigger, $tData['request']);
+                $dateForTrigger = (string)($tData['date'] ?? '');
+                $timeForTrigger = (string)($tData['time'] ?? '');
+                $request = (string)($tData['request'] ?? '');
+                $trigger = new TimerTrigger($dateForTrigger, $timeForTrigger, $request);
                 $trigger->setId($triggerDoc->id()); // Use Firestore document ID as trigger ID
                 $triggers[$trigger->getId()] = $trigger;
             }

--- a/tests/Domain/Bot/Trigger/TimerTriggerTest.php
+++ b/tests/Domain/Bot/Trigger/TimerTriggerTest.php
@@ -245,4 +245,31 @@ final class TimerTriggerTest extends TestCase
 
         Carbon::setTestNow();
     }
+
+    public function test_永続化をシミュレートした際に相対日付が解決された状態で維持される(): void
+    {
+        $timeZone = new \DateTimeZone(Consts::TIMEZONE);
+        // 2024-01-01に「明日」を指定してトリガーを作成
+        Carbon::setTestNow(Carbon::parse("2024-01-01 10:00:00", $timeZone));
+        $trigger = new TimerTrigger("tomorrow", "10:00", "テスト");
+
+        // toArray()は解決済みの日付 (2024/01/02) を返すべき
+        $data = $trigger->toArray();
+        $this->assertEquals("2024/01/02", $data['date']);
+
+        // 翌日 (2024-01-02) に、保存されたデータから再構成
+        Carbon::setTestNow(Carbon::parse("2024-01-02 08:00:00", $timeZone));
+        $reconstructedTrigger = new TimerTrigger($data['date'], $data['time'], $data['request']);
+
+        // 解決済みの「2024/01/02」として扱われ、実行されるべき
+        // 元のテストデータでは 10:00 スケジュール。
+        // スロット [10:00, 10:10) なので、10:00:00 なら実行されるはず
+        Carbon::setTestNow(Carbon::parse("2024-01-02 10:00:00", $timeZone));
+        $this->assertTrue($reconstructedTrigger->shouldRunNow(10));
+
+        // さらにその翌日 (2024-01-03)
+        Carbon::setTestNow(Carbon::parse("2024-01-03 10:00:00", $timeZone));
+        // 「tomorrow」のままだとここでまた実行されてしまうが、解決済みなので実行されないはず
+        $this->assertFalse($reconstructedTrigger->shouldRunNow(10));
+    }
 }


### PR DESCRIPTION
This refactoring addresses a violation of the Single Responsibility Principle in the `TimerTrigger` class by delegating date/time resolution and execution judgment to a new `TriggerSchedule` Value Object. 

Key improvements:
1. **Maintainability**: The complex logic for handling relative dates ('today', 'tomorrow', etc.) and time windows is now encapsulated in a reusable Value Object.
2. **Reliability**: Triggers created with relative dates are now persisted with resolved absolute dates. This ensures that a trigger intended for "tomorrow" stays on that specific date even if the system is restarted or the data is reloaded on a different day.
3. **Type Safety**: Improved defensive programming in `FirestoreBotRepository` with explicit type casting.
4. **Testability**: The scheduling logic is now easier to test in isolation, and a new regression test was added to verify the persistence fix.

---
*PR created automatically by Jules for task [10366818900750477326](https://jules.google.com/task/10366818900750477326) started by @yananob*