### PR TITLE
Add APP_ENV environment variable to deployment workflows

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -23,6 +23,8 @@ jobs:
         FIREBASE_SERVICE_ACCOUNT
       deploy_http_trigger: true
       deploy_event_trigger: true
+      environment_variables: |-
+        APP_ENV=production
     secrets:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_REGION: ${{ secrets.GCP_REGION }}

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -24,6 +24,8 @@ jobs:
         FIREBASE_SERVICE_ACCOUNT
       deploy_http_trigger: true
       deploy_event_trigger: true
+      environment_variables: |-
+        APP_ENV=test
     secrets:
       GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       GCP_REGION: ${{ secrets.GCP_REGION }}


### PR DESCRIPTION
Added the environment_variables argument to the deploy-test.yaml and deploy-prod.yaml workflows to pass APP_ENV (test or production) to the reusable deployment workflow.

---
*PR created automatically by Jules for task [4960962941208894070](https://jules.google.com/task/4960962941208894070) started by @yananob*