### PR TITLE
Downgrade deployment runtime to PHP 8.3

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -23,7 +23,7 @@ jobs:
         FIREBASE_SERVICE_ACCOUNT
       deploy_http_trigger: true
       deploy_event_trigger: true
-      runtime: 'php84'
+      runtime: 'php83'
       environment_variables: |-
         APP_ENV=production
     secrets:

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -24,7 +24,7 @@ jobs:
         FIREBASE_SERVICE_ACCOUNT
       deploy_http_trigger: true
       deploy_event_trigger: true
-      runtime: 'php84'
+      runtime: 'php83'
       environment_variables: |-
         APP_ENV=test
     secrets:


### PR DESCRIPTION
Downgraded the Cloud Functions runtime from `php84` to `php83` in both production and test GitHub Actions workflows. This address the gRPC compatibility issues observed with PHP 8.4. Codebase compatibility with PHP 8.3 was verified via unit tests and static analysis.

Fixes yananob/oml-empowered#634

---
*PR created automatically by Jules for task [15880072733821155365](https://jules.google.com/task/15880072733821155365) started by @yananob*