### PR TITLE
タイマー実行時のメッセージ誤認識バグの修正

### DIFF
--- a/index.php
+++ b/index.php
@@ -170,7 +170,7 @@ function main_event(CloudEventInterface $event): void
                 continue;
             }
 
-            $answer = $chatService->handleMessage($trigger->getRequest())->getText();
+            $answer = $chatService->handleTrigger($trigger)->getText();
             $line->sendPush(
                 bot: $chatService->getLineTarget(),
                 targetId: $botUser->getId(),

--- a/src/Application/ChatApplicationService.php
+++ b/src/Application/ChatApplicationService.php
@@ -5,6 +5,8 @@ namespace App\Application;
 use Exception;
 use App\Domain\Bot\Bot;
 use App\Domain\Bot\Service\CommandAndTriggerService;
+use App\Domain\Bot\ValueObject\Command;
+use App\Domain\Bot\Trigger\TimerTrigger;
 use App\Infrastructure\Gcp\CloudFunctionUtils;
 use App\Application\CommandHandler\CommandHandlerInterface;
 use App\Application\CommandHandler\PostbackHandlerInterface;
@@ -39,6 +41,22 @@ class ChatApplicationService
     public function handleMessage(string $message): BotResponse
     {
         $command = $this->commandAndTriggerService->judgeCommand($message);
+
+        foreach ($this->messageHandlers as $handler) {
+            if ($handler->canHandle($command)) {
+                return $handler->handle($message, $this->bot, $command);
+            }
+        }
+
+        throw new Exception("No handler found for command: " . $command->value);
+    }
+
+    public function handleTrigger(TimerTrigger $trigger): BotResponse
+    {
+        // Prepend a hint to GPT to ensure it understands this is a timer execution.
+        // This prevents GPT from responding with "Timer set" again.
+        $message = "【システム：タイマー実行】\n以下のユーザーからの依頼内容を、今まさに実行してください。\n依頼内容：" . $trigger->getRequest();
+        $command = Command::Other;
 
         foreach ($this->messageHandlers as $handler) {
             if ($handler->canHandle($command)) {

--- a/tests/Application/ChatApplicationServiceTest.php
+++ b/tests/Application/ChatApplicationServiceTest.php
@@ -9,6 +9,7 @@ use App\Application\BotResponse;
 use App\Domain\Bot\Service\CommandAndTriggerService;
 use App\Domain\Bot\ValueObject\Command;
 use App\Domain\Bot\Bot;
+use App\Domain\Bot\Trigger\TimerTrigger;
 use App\Application\CommandHandler\CommandHandlerInterface;
 use App\Application\CommandHandler\PostbackHandlerInterface;
 use PHPUnit\Framework\TestCase;
@@ -90,5 +91,23 @@ final class ChatApplicationServiceTest extends TestCase
     {
         // CFUtils::isTestingEnv() is mocked by environment variable or usually returns true in tests
         $this->assertSame('test', $this->chatService->getLineTarget());
+    }
+
+    public function test_handleTrigger_bypasses_command_judgment(): void
+    {
+        $trigger = new TimerTrigger("today", "12:00", "reminder request");
+
+        // judgeCommand should NOT be called
+        $this->commandAndTriggerServiceMock->expects($this->never())
+            ->method('judgeCommand');
+
+        $this->messageHandlerMock->method('canHandle')->with(Command::Other)->willReturn(true);
+        $this->messageHandlerMock->expects($this->once())
+            ->method('handle')
+            ->with($this->stringContains("reminder request"), $this->bot, Command::Other)
+            ->willReturn(new BotResponse("triggered response"));
+
+        $response = $this->chatService->handleTrigger($trigger);
+        $this->assertSame("triggered response", $response->getText());
     }
 }


### PR DESCRIPTION
タイマー実行時に「タイマーを設定しました」という確認メッセージが返ってしまうバグを修正しました。

原因は、タイマー実行時にも通常のメッセージと同様に「コマンド判定」が行われていたため、実行内容（例：「〜と教えて」）が新しいタイマー設定コマンドとして誤認されていたことにあります。

修正内容：
1. `ChatApplicationService` に `handleTrigger` メソッドを新設し、コマンド判定をスキップして直接チャット回答を生成するようにしました。
2. その際、GPTに対して「これはタイマーの実行である」というヒントを付与することで、確認メッセージではなく本来の依頼内容を実行するように促します。
3. `index.php` の `main_event`（タイマー起動時の処理）を、新しい `handleTrigger` を使うように変更しました。
4. 修正を確認するためのユニットテストを追加しました。

---
*PR created automatically by Jules for task [10784426782371840187](https://jules.google.com/task/10784426782371840187) started by @yananob*