### PR TITLE
タイマー通知におけるボットの個性の反映と整合性の改善

### DIFF
--- a/src/Application/ChatApplicationService.php
+++ b/src/Application/ChatApplicationService.php
@@ -55,7 +55,7 @@ class ChatApplicationService
     {
         // Prepend a hint to GPT to ensure it understands this is a timer execution.
         // This prevents GPT from responding with "Timer set" again.
-        $message = "【システム：タイマー実行】\n以下のユーザーからの依頼内容を、今まさに実行してください。\n依頼内容：" . $trigger->getRequest();
+        $message = "【システム：タイマー実行】\n以下のユーザーからの依頼内容を、あなたの設定された性格や口調に従って今まさに実行してください。\n依頼内容：" . $trigger->getRequest();
         $command = Command::Other;
 
         foreach ($this->messageHandlers as $handler) {

--- a/src/Application/CommandHandler/DefaultChatHandler.php
+++ b/src/Application/CommandHandler/DefaultChatHandler.php
@@ -47,7 +47,11 @@ EOM;
     public function handle(string $message, Bot $bot, Command $command): BotResponse
     {
         $answer = $this->getAnswer($bot, $message);
-        $this->storeConversations($bot, $message, $answer);
+
+        // Avoid storing system-triggered messages (e.g., timer executions) in conversation history.
+        if (!str_starts_with($message, "【システム：タイマー実行】")) {
+            $this->storeConversations($bot, $message, $answer);
+        }
 
         return new BotResponse($answer);
     }

--- a/src/Domain/Bot/Bot.php
+++ b/src/Domain/Bot/Bot.php
@@ -35,20 +35,22 @@ class Bot
 
     public function getBotCharacteristics(): StringList
     {
-        $personalChars = $this->personality->getBotCharacteristics();
-        if ($personalChars->isEmpty() && $this->defaultBot !== null) {
-            return $this->defaultBot->getBotCharacteristics();
+        $chars = $this->personality->getBotCharacteristics();
+        if ($this->defaultBot !== null) {
+            $defaultChars = $this->defaultBot->getBotCharacteristics();
+            $chars = $defaultChars->merge($chars);
         }
-        return $personalChars;
+        return $chars;
     }
 
     public function getHumanCharacteristics(): StringList
     {
-        $personalChars = $this->personality->getHumanCharacteristics();
-        if ($personalChars->isEmpty() && $this->defaultBot !== null) {
-            return $this->defaultBot->getHumanCharacteristics();
+        $chars = $this->personality->getHumanCharacteristics();
+        if ($this->defaultBot !== null) {
+            $defaultChars = $this->defaultBot->getHumanCharacteristics();
+            $chars = $defaultChars->merge($chars);
         }
-        return $personalChars;
+        return $chars;
     }
 
     public function hasHumanCharacteristics(): bool

--- a/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
+++ b/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
@@ -119,10 +119,10 @@ class FirestoreBotRepository implements BotRepository
     {
         $botCollection = $this->getBotCollection($bot->getId());
 
-        // Save main config
+        // Save main config (only personal settings, not default ones)
         $configData = [
-            'bot_characteristics' => $bot->getBotCharacteristics()->toArray(),
-            'human_characteristics' => $bot->getHumanCharacteristics()->toArray(),
+            'bot_characteristics' => $bot->getPersonality()->getBotCharacteristics()->toArray(),
+            'human_characteristics' => $bot->getPersonality()->getHumanCharacteristics()->toArray(),
             'requests' => $bot->getConfigRequests(true, false)->toArray(), // Only personal requests
             'line_target' => $bot->getLineTarget(),
         ];

--- a/tests/Application/CommandHandler/DefaultChatHandlerTest.php
+++ b/tests/Application/CommandHandler/DefaultChatHandlerTest.php
@@ -71,4 +71,24 @@ final class DefaultChatHandlerTest extends TestCase
         $response = $handler->handle("search query", $bot, Command::Other);
         $this->assertSame("Answer with web results", $response->getText());
     }
+
+    public function test_handle_systemTriggerMessageIsNotStored(): void
+    {
+        $handler = new DefaultChatHandler($this->gptMock, $this->convRepoMock, $this->promptService, $this->webSearchMock);
+        $bot = new Bot("test");
+
+        $this->gptMock->method('getAnswer')->willReturnCallback(function($context, $message) {
+            if ($context === DefaultChatHandler::PROMPT_JUDGE_WEB_SEARCH) {
+                return "いいえ";
+            }
+            return "Timer action result";
+        });
+
+        // Should NOT call save
+        $this->convRepoMock->expects($this->never())->method('save');
+
+        $systemMessage = "【システム：タイマー実行】\n依頼内容：お昼です";
+        $response = $handler->handle($systemMessage, $bot, Command::Other);
+        $this->assertSame("Timer action result", $response->getText());
+    }
 }

--- a/tests/Domain/Bot/BotTest.php
+++ b/tests/Domain/Bot/BotTest.php
@@ -30,16 +30,16 @@ final class BotTest extends TestCase
         $this->assertEquals($chars, $this->bot->getBotCharacteristics()->toArray());
     }
 
-    public function test_ボットの特性が設定されておらずデフォルトが提供されている場合にデフォルトを返す(): void
+    public function test_ボットの特性がデフォルトとマージされることを確認する(): void
     {
         $defaultBot = new Bot("defaultBotId");
         $defaultBot->setBotCharacteristics(['デフォルト特性']);
         $botWithDefault = new Bot("botWithDef", $defaultBot);
         $this->assertEquals(['デフォルト特性'], $botWithDefault->getBotCharacteristics()->toArray());
 
-        // 個別設定がある場合はそちらが優先される
+        // 個別設定がある場合はマージされる
         $botWithDefault->setBotCharacteristics(['個別特性']);
-        $this->assertEquals(['個別特性'], $botWithDefault->getBotCharacteristics()->toArray());
+        $this->assertEquals(['デフォルト特性', '個別特性'], $botWithDefault->getBotCharacteristics()->toArray());
     }
 
     public function test_人間の特性を設定および取得する(): void
@@ -56,7 +56,7 @@ final class BotTest extends TestCase
         $this->assertFalse($this->bot->hasHumanCharacteristics());
     }
 
-    public function test_人間の特性が設定されておらずデフォルトが提供されている場合にデフォルトを確認する(): void
+    public function test_人間の特性がデフォルトとマージされることを確認する(): void
     {
         $defaultBot = new Bot("defaultBotId");
         $defaultBot->setHumanCharacteristics(['デフォルト人間特性']);
@@ -65,10 +65,10 @@ final class BotTest extends TestCase
         $this->assertTrue($botWithDefault->hasHumanCharacteristics());
         $this->assertEquals(['デフォルト人間特性'], $botWithDefault->getHumanCharacteristics()->toArray());
 
-        // 個別設定が空でもデフォルトがあればTrue
-        $botWithDefault->setHumanCharacteristics([]);
+        // 個別設定がある場合はマージされる
+        $botWithDefault->setHumanCharacteristics(['個別人間特性']);
         $this->assertTrue($botWithDefault->hasHumanCharacteristics());
-        $this->assertEquals(['デフォルト人間特性'], $botWithDefault->getHumanCharacteristics()->toArray());
+        $this->assertEquals(['デフォルト人間特性', '個別人間特性'], $botWithDefault->getHumanCharacteristics()->toArray());
     }
 
     public function test_設定リクエストを設定および取得する(): void

--- a/tests/Infrastructure/Persistence/Firestore/FirestoreBotRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/Firestore/FirestoreBotRepositoryTest.php
@@ -87,7 +87,7 @@ final class FirestoreBotRepositoryTest extends TestCase
         $this->repository->findDefault();
     }
 
-    public function test_findByIdが成功する(): void
+    public function test_findByIdが成功しデフォルトと個別設定がマージされる(): void
     {
         $botId = 'test-bot';
 
@@ -106,7 +106,7 @@ final class FirestoreBotRepositoryTest extends TestCase
 
         $this->assertInstanceOf(Bot::class, $bot);
         $this->assertEquals($botId, $bot->getId());
-        $this->assertEquals(['test-char'], $bot->getBotCharacteristics()->toArray());
+        $this->assertEquals(['default-char', 'test-char'], $bot->getBotCharacteristics()->toArray());
     }
 
     public function test_findByIdがトリガーをロードする(): void
@@ -195,16 +195,20 @@ final class FirestoreBotRepositoryTest extends TestCase
         $this->assertEquals('user-bot-1', $bots[0]->getId());
     }
 
-    public function test_saveが成功する(): void
+    public function test_saveが成功し個別設定のみ保存される(): void
     {
-        $bot = new Bot('test-bot');
-        $bot->setBotCharacteristics(['char']);
+        $defaultBot = new Bot('default');
+        $defaultBot->setBotCharacteristics(['default-char']);
+
+        $bot = new Bot('test-bot', $defaultBot);
+        $bot->setBotCharacteristics(['personal-char']);
 
         [$botCollMock, $configDocMock] = $this->createBotMocks();
 
         $this->documentRootMock->method('collection')->with('test-bot')->willReturn($botCollMock);
         $configDocMock->expects($this->once())->method('set')->with($this->callback(function($data) {
-            return $data['bot_characteristics'] === ['char'];
+            // Should only contain 'personal-char', not 'default-char'
+            return $data['bot_characteristics'] === ['personal-char'];
         }));
 
         $this->repository->save($bot);


### PR DESCRIPTION
タイマー通知時にボットの個性（性格や口調など）が反映されない問題を修正しました。

主な変更点：
1. **ドメイン層 (`Bot.php`)**: ボットおよび人間の特性を取得する際、デフォルト設定と個別設定をマージして返すように変更しました。これにより、ベースとなる性格を維持しつつ個別のカスタマイズを反映できます。
2. **インフラ層 (`FirestoreBotRepository.php`)**: 保存時にデフォルト設定を保存せず、個別設定のみを保存するように修正しました。これにより、将来的にデフォルト設定が更新された場合、既存のユーザーにもその変更が波及するようになります。
3. **アプリケーション層 (`ChatApplicationService.php`)**: タイマー実行時のシステムヒントを更新し、設定された性格や口調を維持して実行するよう AI に明示的に指示するようにしました。
4. **ハンドラー層 (`DefaultChatHandler.php`)**: システムヒントを含むメッセージが会話履歴に保存されないようにし、ユーザーの履歴が技術的な指示で汚れるのを防ぎました。
5. **テスト**: 上記の挙動を検証するためのテストケースを `BotTest`, `FirestoreBotRepositoryTest`, `DefaultChatHandlerTest` に追加・更新しました。

---
*PR created automatically by Jules for task [4983294932803062259](https://jules.google.com/task/4983294932803062259) started by @yananob*