### PR TITLE
Refactor: Introduce Message Value Object and centralize prompts

### DIFF
--- a/src/Application/ChatApplicationService.php
+++ b/src/Application/ChatApplicationService.php
@@ -10,6 +10,8 @@ use App\Domain\Bot\Trigger\TimerTrigger;
 use App\Infrastructure\Gcp\CloudFunctionUtils;
 use App\Application\CommandHandler\CommandHandlerInterface;
 use App\Application\CommandHandler\PostbackHandlerInterface;
+use App\Domain\Bot\ValueObject\Message;
+use App\Domain\Bot\Messages;
 
 class ChatApplicationService
 {
@@ -38,9 +40,10 @@ class ChatApplicationService
         $this->postbackHandlers = $postbackHandlers;
     }
 
-    public function handleMessage(string $message): BotResponse
+    public function handleMessage(string $messageContent): BotResponse
     {
-        $command = $this->commandAndTriggerService->judgeCommand($message);
+        $command = $this->commandAndTriggerService->judgeCommand($messageContent);
+        $message = new Message($messageContent, isSystem: false);
 
         foreach ($this->messageHandlers as $handler) {
             if ($handler->canHandle($command)) {
@@ -55,7 +58,8 @@ class ChatApplicationService
     {
         // Prepend a hint to GPT to ensure it understands this is a timer execution.
         // This prevents GPT from responding with "Timer set" again.
-        $message = "【システム：タイマー実行】\n以下のユーザーからの依頼内容を、あなたの設定された性格や口調に従って今まさに実行してください。\n依頼内容：" . $trigger->getRequest();
+        $messageContent = Messages::SYSTEM_TIMER_INSTRUCTION . $trigger->getRequest();
+        $message = new Message($messageContent, isSystem: true);
         $command = Command::Other;
 
         foreach ($this->messageHandlers as $handler) {

--- a/src/Application/CommandHandler/AddTriggerHandler.php
+++ b/src/Application/CommandHandler/AddTriggerHandler.php
@@ -9,6 +9,7 @@ use App\Domain\Bot\Bot;
 use App\Domain\Bot\BotRepository;
 use App\Domain\Bot\Service\CommandAndTriggerService;
 use App\Application\BotResponse;
+use App\Domain\Bot\ValueObject\Message;
 
 class AddTriggerHandler implements CommandHandlerInterface
 {
@@ -28,12 +29,12 @@ class AddTriggerHandler implements CommandHandlerInterface
         return $command === Command::AddOneTimeTrigger || $command === Command::AddDailyTrigger;
     }
 
-    public function handle(string $message, Bot $bot, Command $command): BotResponse
+    public function handle(Message $message, Bot $bot, Command $command): BotResponse
     {
         if ($command === Command::AddOneTimeTrigger) {
-            $trigger = $this->commandAndTriggerService->generateOneTimeTrigger($message);
+            $trigger = $this->commandAndTriggerService->generateOneTimeTrigger($message->getContent());
         } else {
-            $trigger = $this->commandAndTriggerService->generateDailyTrigger($message);
+            $trigger = $this->commandAndTriggerService->generateDailyTrigger($message->getContent());
         }
 
         $bot->addTrigger($trigger);

--- a/src/Application/CommandHandler/CommandHandlerInterface.php
+++ b/src/Application/CommandHandler/CommandHandlerInterface.php
@@ -7,9 +7,10 @@ namespace App\Application\CommandHandler;
 use App\Domain\Bot\ValueObject\Command;
 use App\Domain\Bot\Bot;
 use App\Application\BotResponse;
+use App\Domain\Bot\ValueObject\Message;
 
 interface CommandHandlerInterface
 {
     public function canHandle(Command $command): bool;
-    public function handle(string $message, Bot $bot, Command $command): BotResponse;
+    public function handle(Message $message, Bot $bot, Command $command): BotResponse;
 }

--- a/src/Application/CommandHandler/DefaultChatHandler.php
+++ b/src/Application/CommandHandler/DefaultChatHandler.php
@@ -12,6 +12,8 @@ use App\Domain\Bot\Service\ChatPromptService;
 use App\Domain\Bot\Service\WebSearchInterface;
 use App\Domain\Bot\Service\GptInterface;
 use App\Application\BotResponse;
+use App\Domain\Bot\ValueObject\Message;
+use App\Domain\Bot\Messages;
 
 class DefaultChatHandler implements CommandHandlerInterface
 {
@@ -21,11 +23,6 @@ class DefaultChatHandler implements CommandHandlerInterface
     private ?WebSearchInterface $webSearchTool;
 
     const RECENT_CONVERSATIONS_COUNT_FOR_GPT = 10;
-    const PROMPT_JUDGE_WEB_SEARCH = <<<EOM
-あなたはユーザーからのメッセージを分析するアシスタントです。
-ユーザーのメッセージに答えるためにWeb検索が必要かどうかを判断してください。
-Web検索が必要な場合は「はい」、そうでない場合は「いいえ」とだけ答えてください。
-EOM;
 
     public function __construct(
         GptInterface $gpt,
@@ -44,19 +41,19 @@ EOM;
         return $command === Command::Other;
     }
 
-    public function handle(string $message, Bot $bot, Command $command): BotResponse
+    public function handle(Message $message, Bot $bot, Command $command): BotResponse
     {
         $answer = $this->getAnswer($bot, $message);
 
         // Avoid storing system-triggered messages (e.g., timer executions) in conversation history.
-        if (!str_starts_with($message, "【システム：タイマー実行】")) {
-            $this->storeConversations($bot, $message, $answer);
+        if (!$message->isSystem()) {
+            $this->storeConversations($bot, $message->getContent(), $answer);
         }
 
         return new BotResponse($answer);
     }
 
-    private function getAnswer(Bot $bot, string $message): string
+    private function getAnswer(Bot $bot, Message $message): string
     {
         $recentConversations = $this->conversationRepository->findByBotId(
             $bot->getId(),
@@ -64,9 +61,9 @@ EOM;
         );
 
         $webSearchResults = null;
-        if ($this->shouldPerformWebSearch($message)) {
+        if ($this->shouldPerformWebSearch($message->getContent())) {
             if ($this->webSearchTool instanceof WebSearchInterface) {
-                $webSearchResults = $this->webSearchTool->search($message, 5);
+                $webSearchResults = $this->webSearchTool->search($message->getContent(), 5);
             } else {
                 $webSearchResults = "Error: Web search tool is not configured properly or failed to initialize.";
             }
@@ -81,22 +78,22 @@ EOM;
                 $configRequests,
                 $webSearchResults
             ),
-            message: $message,
+            message: $message->getContent(),
         );
     }
 
-    private function shouldPerformWebSearch(string $message): bool
+    private function shouldPerformWebSearch(string $messageContent): bool
     {
         $response = trim($this->gpt->getAnswer(
-            context: self::PROMPT_JUDGE_WEB_SEARCH,
-            message: $message,
+            context: Messages::PROMPT_JUDGE_WEB_SEARCH,
+            message: $messageContent,
         ));
         return $response === "はい";
     }
 
-    private function storeConversations(Bot $bot, string $message, string $answer): void
+    private function storeConversations(Bot $bot, string $messageContent, string $answer): void
     {
-        $humanConversation = new Conversation($bot->getId(), "human", $message);
+        $humanConversation = new Conversation($bot->getId(), "human", $messageContent);
         $this->conversationRepository->save($humanConversation);
 
         $botConversation = new Conversation($bot->getId(), "bot", $answer);

--- a/src/Application/CommandHandler/HelpHandler.php
+++ b/src/Application/CommandHandler/HelpHandler.php
@@ -8,6 +8,7 @@ use App\Domain\Bot\ValueObject\Command;
 use App\Domain\Bot\Bot;
 use App\Application\BotResponse;
 use App\Domain\Bot\Messages;
+use App\Domain\Bot\ValueObject\Message;
 
 class HelpHandler implements CommandHandlerInterface
 {
@@ -16,7 +17,7 @@ class HelpHandler implements CommandHandlerInterface
         return $command === Command::ShowHelp;
     }
 
-    public function handle(string $message, Bot $bot, Command $command): BotResponse
+    public function handle(Message $message, Bot $bot, Command $command): BotResponse
     {
         return new BotResponse(Messages::HELP);
     }

--- a/src/Application/CommandHandler/RemoveTriggerHandler.php
+++ b/src/Application/CommandHandler/RemoveTriggerHandler.php
@@ -9,6 +9,7 @@ use App\Domain\Bot\Bot;
 use App\Application\BotResponse;
 use App\Domain\Bot\Consts;
 use App\Infrastructure\Line\LineTools;
+use App\Domain\Bot\ValueObject\Message;
 
 class RemoveTriggerHandler implements CommandHandlerInterface
 {
@@ -17,7 +18,7 @@ class RemoveTriggerHandler implements CommandHandlerInterface
         return $command === Command::RemoveTrigger;
     }
 
-    public function handle(string $message, Bot $bot, Command $command): BotResponse
+    public function handle(Message $message, Bot $bot, Command $command): BotResponse
     {
         $answer = "どのタイマーを止めますか？";
         $quickReply = LineTools::convertTriggersToQuickReply(Consts::CMD_REMOVE_TRIGGER, $bot->getTriggers());

--- a/src/Domain/Bot/Messages.php
+++ b/src/Domain/Bot/Messages.php
@@ -20,4 +20,14 @@ class Messages
 (4)指定した時間のメッセージをやめる
 　　例：毎朝のメッセージを止めて
 EOM;
+
+    const SYSTEM_TIMER_HINT = "【システム：タイマー実行】";
+
+    const SYSTEM_TIMER_INSTRUCTION = self::SYSTEM_TIMER_HINT . "\n以下のユーザーからの依頼内容を、あなたの設定された性格や口調に従って今まさに実行してください。\n依頼内容：";
+
+    const PROMPT_JUDGE_WEB_SEARCH = <<<EOM
+あなたはユーザーからのメッセージを分析するアシスタントです。
+ユーザーのメッセージに答えるためにWeb検索が必要かどうかを判断してください。
+Web検索が必要な場合は「はい」、そうでない場合は「いいえ」とだけ答えてください。
+EOM;
 }

--- a/src/Domain/Bot/ValueObject/Message.php
+++ b/src/Domain/Bot/ValueObject/Message.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Bot\ValueObject;
+
+/**
+ * Represents a message in the chat system.
+ */
+class Message
+{
+    private string $content;
+    private bool $isSystem;
+
+    public function __construct(string $content, bool $isSystem = false)
+    {
+        $this->content = $content;
+        $this->isSystem = $isSystem;
+    }
+
+    public function getContent(): string
+    {
+        return $this->content;
+    }
+
+    public function isSystem(): bool
+    {
+        return $this->isSystem;
+    }
+
+    public function __toString(): string
+    {
+        return $this->content;
+    }
+}

--- a/tests/Application/ChatApplicationServiceTest.php
+++ b/tests/Application/ChatApplicationServiceTest.php
@@ -10,6 +10,7 @@ use App\Domain\Bot\Service\CommandAndTriggerService;
 use App\Domain\Bot\ValueObject\Command;
 use App\Domain\Bot\Bot;
 use App\Domain\Bot\Trigger\TimerTrigger;
+use App\Domain\Bot\ValueObject\Message;
 use App\Application\CommandHandler\CommandHandlerInterface;
 use App\Application\CommandHandler\PostbackHandlerInterface;
 use PHPUnit\Framework\TestCase;
@@ -45,7 +46,9 @@ final class ChatApplicationServiceTest extends TestCase
         $this->messageHandlerMock->method('canHandle')->with(Command::Other)->willReturn(true);
         $this->messageHandlerMock->expects($this->once())
             ->method('handle')
-            ->with("hello", $this->bot, Command::Other)
+            ->with($this->callback(function (Message $message) {
+                return $message->getContent() === "hello" && !$message->isSystem();
+            }), $this->bot, Command::Other)
             ->willReturn(new BotResponse("hi"));
 
         $response = $this->chatService->handleMessage("hello");
@@ -104,7 +107,9 @@ final class ChatApplicationServiceTest extends TestCase
         $this->messageHandlerMock->method('canHandle')->with(Command::Other)->willReturn(true);
         $this->messageHandlerMock->expects($this->once())
             ->method('handle')
-            ->with($this->stringContains("reminder request"), $this->bot, Command::Other)
+            ->with($this->callback(function (Message $message) {
+                return str_contains($message->getContent(), "reminder request") && $message->isSystem();
+            }), $this->bot, Command::Other)
             ->willReturn(new BotResponse("triggered response"));
 
         $response = $this->chatService->handleTrigger($trigger);

--- a/tests/Application/CommandHandler/AddTriggerHandlerTest.php
+++ b/tests/Application/CommandHandler/AddTriggerHandlerTest.php
@@ -10,6 +10,7 @@ use App\Domain\Bot\Bot;
 use App\Domain\Bot\BotRepository;
 use App\Domain\Bot\Service\CommandAndTriggerService;
 use App\Domain\Bot\Trigger\TimerTrigger;
+use App\Domain\Bot\ValueObject\Message;
 use PHPUnit\Framework\TestCase;
 
 final class AddTriggerHandlerTest extends TestCase
@@ -37,7 +38,8 @@ final class AddTriggerHandlerTest extends TestCase
         $cmdServiceMock->method('generateOneTimeTrigger')->willReturn($trigger);
         $repoMock->expects($this->once())->method('save')->with($bot);
 
-        $response = $handler->handle("today 12:00 test", $bot, Command::AddOneTimeTrigger);
+        $message = new Message("today 12:00 test", false);
+        $response = $handler->handle($message, $bot, Command::AddOneTimeTrigger);
         $this->assertSame("タイマーを追加しました：" . $trigger, $response->getText());
         $this->assertCount(1, $bot->getTriggers());
     }
@@ -54,7 +56,8 @@ final class AddTriggerHandlerTest extends TestCase
         $cmdServiceMock->method('generateDailyTrigger')->willReturn($trigger);
         $repoMock->expects($this->once())->method('save')->with($bot);
 
-        $response = $handler->handle("everyday 12:00 test", $bot, Command::AddDailyTrigger);
+        $message = new Message("everyday 12:00 test", false);
+        $response = $handler->handle($message, $bot, Command::AddDailyTrigger);
         $this->assertSame("タイマーを追加しました：" . $trigger, $response->getText());
         $this->assertCount(1, $bot->getTriggers());
     }

--- a/tests/Application/CommandHandler/DefaultChatHandlerTest.php
+++ b/tests/Application/CommandHandler/DefaultChatHandlerTest.php
@@ -11,6 +11,8 @@ use App\Domain\Conversation\ConversationRepository;
 use App\Domain\Bot\Service\ChatPromptService;
 use App\Domain\Bot\Service\WebSearchInterface;
 use App\Domain\Bot\Service\GptInterface;
+use App\Domain\Bot\ValueObject\Message;
+use App\Domain\Bot\Messages;
 use PHPUnit\Framework\TestCase;
 
 final class DefaultChatHandlerTest extends TestCase
@@ -42,7 +44,7 @@ final class DefaultChatHandlerTest extends TestCase
 
         // Use willReturnCallback to handle the various calls to getAnswer
         $this->gptMock->method('getAnswer')->willReturnCallback(function($context, $message) {
-            if ($context === DefaultChatHandler::PROMPT_JUDGE_WEB_SEARCH) {
+            if ($context === Messages::PROMPT_JUDGE_WEB_SEARCH) {
                 return "いいえ";
             }
             return "world";
@@ -50,7 +52,8 @@ final class DefaultChatHandlerTest extends TestCase
 
         $this->convRepoMock->expects($this->exactly(2))->method('save');
 
-        $response = $handler->handle("hello", $bot, Command::Other);
+        $message = new Message("hello", false);
+        $response = $handler->handle($message, $bot, Command::Other);
         $this->assertSame("world", $response->getText());
     }
 
@@ -60,7 +63,7 @@ final class DefaultChatHandlerTest extends TestCase
         $bot = new Bot("test");
 
         $this->gptMock->method('getAnswer')->willReturnCallback(function($context, $message) {
-            if ($context === DefaultChatHandler::PROMPT_JUDGE_WEB_SEARCH) {
+            if ($context === Messages::PROMPT_JUDGE_WEB_SEARCH) {
                 return "はい";
             }
             return "Answer with web results";
@@ -68,7 +71,8 @@ final class DefaultChatHandlerTest extends TestCase
 
         $this->webSearchMock->expects($this->once())->method('search')->willReturn("Web info");
 
-        $response = $handler->handle("search query", $bot, Command::Other);
+        $message = new Message("search query", false);
+        $response = $handler->handle($message, $bot, Command::Other);
         $this->assertSame("Answer with web results", $response->getText());
     }
 
@@ -78,7 +82,7 @@ final class DefaultChatHandlerTest extends TestCase
         $bot = new Bot("test");
 
         $this->gptMock->method('getAnswer')->willReturnCallback(function($context, $message) {
-            if ($context === DefaultChatHandler::PROMPT_JUDGE_WEB_SEARCH) {
+            if ($context === Messages::PROMPT_JUDGE_WEB_SEARCH) {
                 return "いいえ";
             }
             return "Timer action result";
@@ -87,8 +91,8 @@ final class DefaultChatHandlerTest extends TestCase
         // Should NOT call save
         $this->convRepoMock->expects($this->never())->method('save');
 
-        $systemMessage = "【システム：タイマー実行】\n依頼内容：お昼です";
-        $response = $handler->handle($systemMessage, $bot, Command::Other);
+        $message = new Message("お昼です", true);
+        $response = $handler->handle($message, $bot, Command::Other);
         $this->assertSame("Timer action result", $response->getText());
     }
 }

--- a/tests/Application/CommandHandler/HelpHandlerTest.php
+++ b/tests/Application/CommandHandler/HelpHandlerTest.php
@@ -8,6 +8,7 @@ use App\Application\CommandHandler\HelpHandler;
 use App\Domain\Bot\ValueObject\Command;
 use App\Domain\Bot\Bot;
 use App\Domain\Bot\Messages;
+use App\Domain\Bot\ValueObject\Message;
 use PHPUnit\Framework\TestCase;
 
 final class HelpHandlerTest extends TestCase
@@ -23,7 +24,8 @@ final class HelpHandlerTest extends TestCase
     {
         $handler = new HelpHandler();
         $bot = new Bot("test");
-        $response = $handler->handle("help", $bot, Command::ShowHelp);
+        $message = new Message("help", false);
+        $response = $handler->handle($message, $bot, Command::ShowHelp);
         $this->assertSame(Messages::HELP, $response->getText());
     }
 }

--- a/tests/Application/CommandHandler/RemoveTriggerHandlerTest.php
+++ b/tests/Application/CommandHandler/RemoveTriggerHandlerTest.php
@@ -8,6 +8,7 @@ use App\Application\CommandHandler\RemoveTriggerHandler;
 use App\Domain\Bot\ValueObject\Command;
 use App\Domain\Bot\Bot;
 use App\Domain\Bot\Trigger\TimerTrigger;
+use App\Domain\Bot\ValueObject\Message;
 use PHPUnit\Framework\TestCase;
 
 final class RemoveTriggerHandlerTest extends TestCase
@@ -25,7 +26,8 @@ final class RemoveTriggerHandlerTest extends TestCase
         $bot = new Bot("test");
         $bot->addTrigger(new TimerTrigger("today", "12:00", "test"));
 
-        $response = $handler->handle("stop", $bot, Command::RemoveTrigger);
+        $message = new Message("stop", false);
+        $response = $handler->handle($message, $bot, Command::RemoveTrigger);
         $this->assertSame("どのタイマーを止めますか？", $response->getText());
         $this->assertNotNull($response->getQuickReply());
     }


### PR DESCRIPTION
This PR improves maintainability by eliminating magic strings and primitive obsession.
- Introduced `Message` Value Object to encapsulate message content and system status.
- Centralized system hints and GPT prompts in `App\Domain\Bot\Messages`.
- Updated `CommandHandlerInterface` and its implementations to use the `Message` VO.
- Decoupled conversation history storage logic from hardcoded string prefixes.

---
*PR created automatically by Jules for task [13020403287293152515](https://jules.google.com/task/13020403287293152515) started by @yananob*