### PR TITLE
AppConfig.phpのメンテナンス（APP_ENV必須化と不要メソッド削除）

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -72,5 +72,7 @@ jobs:
         echo $DECODED_BASE64 | base64 --decode > configs/gpt.json
 
     - name: Test with phpunit
+      env:
+        APP_ENV: test
       run: |
         bash tests/run_tests.sh

--- a/src/AppConfig.php
+++ b/src/AppConfig.php
@@ -9,7 +9,6 @@ namespace App;
  * 環境は`APP_ENV`環境変数によって決定されます。
  *
  * サポートされる環境: 'production', 'test', 'development'。
- * `APP_ENV`が設定されていない場合、デフォルトは'development'です。
  */
 class AppConfig
 {
@@ -17,10 +16,15 @@ class AppConfig
      * 現在のアプリケーション環境を取得します。
      *
      * @return string 現在の環境 ('production', 'test', または 'development')。
+     * @throws \RuntimeException APP_ENV環境変数が設定されていない場合。
      */
     public static function getEnvironment(): string
     {
-        return getenv('APP_ENV') ?: 'development';
+        $env = getenv('APP_ENV');
+        if ($env === false || $env === '') {
+            throw new \RuntimeException('APP_ENV environment variable is not set.');
+        }
+        return $env;
     }
 
     /**
@@ -61,34 +65,6 @@ class AppConfig
 
         // development (local)
         return '';
-    }
-
-    /**
-     * LINEメッセージ配信のターゲットとなるユーザー/グループIDを取得します。
-     *
-     * @return string LINEターゲットID。
-     */
-    public static function getLineDeliverTarget(): string
-    {
-        return match (self::getEnvironment()) {
-            'production' => 'ai-bot',
-            'test' => 'nobu',
-            default => 'nobu',
-        };
-    }
-
-    /**
-     * 静的ファイルのベースURLを取得します。
-     *
-     * @return string ベースURL。
-     */
-    public static function getStaticBaseUrl(): string
-    {
-        return match (self::getEnvironment()) {
-            'production' => 'https://storage.googleapis.com/line-ai-bot-static',
-            'test' => 'https://storage.googleapis.com/line-ai-bot-static/test',
-            default => '/public',
-        };
     }
 
     /**


### PR DESCRIPTION
AppConfig.phpのメンテナンスを行いました。
1. getEnvironment()においてAPP_ENV環境変数を必須とし、未設定の場合はRuntimeExceptionを投げるように変更しました。これに伴い、デフォルト値（'development'）を削除しました。
2. 不要になったメソッド getLineDeliverTarget() および getStaticBaseUrl() を削除しました。
3. クラスのPHPDocを更新し、環境変数が必須であることを明記しました。

動作確認として、APP_ENV=test を指定した状態で ./tests/run_tests.sh を実行し、既存のテストがすべてパスすることを確認済みです。

Fixes #135

---
*PR created automatically by Jules for task [12214566927450931395](https://jules.google.com/task/12214566927450931395) started by @yananob*