### PR TITLE
不足しているユニットテストの追加と既存テストの改善

### DIFF
--- a/tests/AppConfigTest.php
+++ b/tests/AppConfigTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use App\AppConfig;
+use PHPUnit\Framework\TestCase;
+
+final class AppConfigTest extends TestCase
+{
+    private string|false $originalEnv;
+    private string|false $originalKService;
+
+    protected function setUp(): void
+    {
+        $this->originalEnv = getenv('APP_ENV');
+        $this->originalKService = getenv('K_SERVICE');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalEnv !== false) {
+            putenv("APP_ENV={$this->originalEnv}");
+        } else {
+            putenv("APP_ENV");
+        }
+
+        if ($this->originalKService !== false) {
+            putenv("K_SERVICE={$this->originalKService}");
+        } else {
+            putenv("K_SERVICE");
+        }
+    }
+
+    public function test_getEnvironment_returns_value_from_env(): void
+    {
+        putenv('APP_ENV=production');
+        $this->assertSame('production', AppConfig::getEnvironment());
+
+        putenv('APP_ENV=test');
+        $this->assertSame('test', AppConfig::getEnvironment());
+    }
+
+    public function test_getEnvironment_throws_exception_if_not_set(): void
+    {
+        putenv('APP_ENV'); // Unset
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('APP_ENV environment variable is not set.');
+        AppConfig::getEnvironment();
+    }
+
+    public function test_getFirestoreRootCollection_returns_correct_value(): void
+    {
+        putenv('APP_ENV=production');
+        $this->assertSame('ai-bot', AppConfig::getFirestoreRootCollection());
+
+        putenv('APP_ENV=test');
+        $this->assertSame('ai-bot-test', AppConfig::getFirestoreRootCollection());
+
+        putenv('APP_ENV=development');
+        $this->assertSame('ai-bot-test', AppConfig::getFirestoreRootCollection());
+    }
+
+    public function test_getBasePath_returns_correct_value(): void
+    {
+        putenv('APP_ENV=production');
+        $this->assertSame('/line-ai-bot', AppConfig::getBasePath());
+
+        putenv('APP_ENV=test');
+        putenv('K_SERVICE=my-test-func');
+        $this->assertSame('/my-test-func', AppConfig::getBasePath());
+
+        putenv('K_SERVICE'); // Unset
+        $this->assertSame('/line-ai-bot-test', AppConfig::getBasePath());
+
+        putenv('APP_ENV=development');
+        $this->assertSame('', AppConfig::getBasePath());
+    }
+
+    public function test_isDevelopment_returns_true_only_in_development(): void
+    {
+        putenv('APP_ENV=development');
+        $this->assertTrue(AppConfig::isDevelopment());
+
+        putenv('APP_ENV=production');
+        $this->assertFalse(AppConfig::isDevelopment());
+    }
+
+    public function test_isTest_returns_true_only_in_test(): void
+    {
+        putenv('APP_ENV=test');
+        $this->assertTrue(AppConfig::isTest());
+
+        putenv('APP_ENV=production');
+        $this->assertFalse(AppConfig::isTest());
+    }
+
+    public function test_getFunctionName_returns_k_service(): void
+    {
+        putenv('K_SERVICE=hello-func');
+        $this->assertSame('hello-func', AppConfig::getFunctionName());
+
+        putenv('K_SERVICE');
+        $this->assertSame('default', AppConfig::getFunctionName('default'));
+    }
+}

--- a/tests/AppConfigTest.php
+++ b/tests/AppConfigTest.php
@@ -33,7 +33,7 @@ final class AppConfigTest extends TestCase
         }
     }
 
-    public function test_getEnvironment_returns_value_from_env(): void
+    public function test_getEnvironmentは環境変数から値を取得する(): void
     {
         putenv('APP_ENV=production');
         $this->assertSame('production', AppConfig::getEnvironment());
@@ -42,7 +42,7 @@ final class AppConfigTest extends TestCase
         $this->assertSame('test', AppConfig::getEnvironment());
     }
 
-    public function test_getEnvironment_throws_exception_if_not_set(): void
+    public function test_getEnvironmentは環境変数が設定されていない場合に例外を投げる(): void
     {
         putenv('APP_ENV'); // Unset
         $this->expectException(\RuntimeException::class);
@@ -50,7 +50,7 @@ final class AppConfigTest extends TestCase
         AppConfig::getEnvironment();
     }
 
-    public function test_getFirestoreRootCollection_returns_correct_value(): void
+    public function test_getFirestoreRootCollectionは正しい値を返す(): void
     {
         putenv('APP_ENV=production');
         $this->assertSame('ai-bot', AppConfig::getFirestoreRootCollection());
@@ -62,7 +62,7 @@ final class AppConfigTest extends TestCase
         $this->assertSame('ai-bot-test', AppConfig::getFirestoreRootCollection());
     }
 
-    public function test_getBasePath_returns_correct_value(): void
+    public function test_getBasePathは正しい値を返す(): void
     {
         putenv('APP_ENV=production');
         $this->assertSame('/line-ai-bot', AppConfig::getBasePath());
@@ -78,7 +78,7 @@ final class AppConfigTest extends TestCase
         $this->assertSame('', AppConfig::getBasePath());
     }
 
-    public function test_isDevelopment_returns_true_only_in_development(): void
+    public function test_isDevelopmentはdevelopmentの場合のみtrueを返す(): void
     {
         putenv('APP_ENV=development');
         $this->assertTrue(AppConfig::isDevelopment());
@@ -87,7 +87,7 @@ final class AppConfigTest extends TestCase
         $this->assertFalse(AppConfig::isDevelopment());
     }
 
-    public function test_isTest_returns_true_only_in_test(): void
+    public function test_isTestはtestの場合のみtrueを返す(): void
     {
         putenv('APP_ENV=test');
         $this->assertTrue(AppConfig::isTest());
@@ -96,7 +96,7 @@ final class AppConfigTest extends TestCase
         $this->assertFalse(AppConfig::isTest());
     }
 
-    public function test_getFunctionName_returns_k_service(): void
+    public function test_getFunctionNameはK_SERVICEを返す(): void
     {
         putenv('K_SERVICE=hello-func');
         $this->assertSame('hello-func', AppConfig::getFunctionName());

--- a/tests/Application/Config/ConfigApplicationServiceTest.php
+++ b/tests/Application/Config/ConfigApplicationServiceTest.php
@@ -28,7 +28,7 @@ final class ConfigApplicationServiceTest extends TestCase
         );
     }
 
-    public function test_renderIndex_calls_repository_and_returns_string(): void
+    public function test_renderIndexはリポジトリを呼び出しHTMLを返す(): void
     {
         $this->repositoryMock->expects($this->once())
             ->method('findAllConfigs')
@@ -39,7 +39,7 @@ final class ConfigApplicationServiceTest extends TestCase
         $this->assertStringContainsString('Bot 1', $html);
     }
 
-    public function test_renderEdit_calls_repository_when_botId_provided(): void
+    public function test_renderEditはbotIdが指定された場合にリポジトリを呼び出す(): void
     {
         $botId = 'test-bot';
         $this->repositoryMock->expects($this->once())
@@ -52,7 +52,7 @@ final class ConfigApplicationServiceTest extends TestCase
         $this->assertStringContainsString('Test Bot', $html);
     }
 
-    public function test_renderTriggers_calls_repository(): void
+    public function test_renderTriggersはリポジトリを呼び出す(): void
     {
         $botId = 'test-bot';
         $this->repositoryMock->expects($this->once())
@@ -69,7 +69,7 @@ final class ConfigApplicationServiceTest extends TestCase
         $this->assertStringContainsString('Hello', $html);
     }
 
-    public function test_renderTriggerEdit_calls_repository(): void
+    public function test_renderTriggerEditはリポジトリを呼び出す(): void
     {
         $botId = 'test-bot';
         $triggerId = 'trigger-1';
@@ -87,7 +87,7 @@ final class ConfigApplicationServiceTest extends TestCase
         $this->assertStringContainsString('Hello', $html);
     }
 
-    public function test_saveBotConfig_calls_repository(): void
+    public function test_saveBotConfigはリポジトリを呼び出す(): void
     {
         $botId = 'test-bot';
         $data = ['bot_name' => 'New Name'];
@@ -98,7 +98,7 @@ final class ConfigApplicationServiceTest extends TestCase
         $this->service->saveBotConfig($botId, $data);
     }
 
-    public function test_saveTrigger_calls_repository(): void
+    public function test_saveTriggerはリポジトリを呼び出す(): void
     {
         $botId = 'test-bot';
         $triggerId = 'trigger-1';
@@ -110,7 +110,7 @@ final class ConfigApplicationServiceTest extends TestCase
         $this->service->saveTrigger($botId, $triggerId, $data);
     }
 
-    public function test_deleteTrigger_calls_repository(): void
+    public function test_deleteTriggerはリポジトリを呼び出す(): void
     {
         $botId = 'test-bot';
         $triggerId = 'trigger-1';
@@ -121,7 +121,7 @@ final class ConfigApplicationServiceTest extends TestCase
         $this->service->deleteTrigger($botId, $triggerId);
     }
 
-    public function test_deleteBot_calls_repository(): void
+    public function test_deleteBotはリポジトリを呼び出す(): void
     {
         $botId = 'test-bot';
         $this->repositoryMock->expects($this->once())

--- a/tests/Application/Config/ConfigApplicationServiceTest.php
+++ b/tests/Application/Config/ConfigApplicationServiceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application\Config;
+
+use App\Application\Config\ConfigApplicationService;
+use App\Domain\Config\ConfigRepository;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigApplicationServiceTest extends TestCase
+{
+    private $repositoryMock;
+    private ConfigApplicationService $service;
+    private string $viewsPath;
+    private string $cachePath;
+
+    protected function setUp(): void
+    {
+        $this->repositoryMock = $this->createMock(ConfigRepository::class);
+        $this->viewsPath = __DIR__ . '/../../../views';
+        $this->cachePath = '/tmp/bladeone_cache_test';
+
+        $this->service = new ConfigApplicationService(
+            $this->repositoryMock,
+            $this->viewsPath,
+            $this->cachePath
+        );
+    }
+
+    public function test_renderIndex_calls_repository_and_returns_string(): void
+    {
+        $this->repositoryMock->expects($this->once())
+            ->method('findAllConfigs')
+            ->willReturn(['bot_1' => ['bot_name' => 'Bot 1']]);
+
+        $html = $this->service->renderIndex();
+        $this->assertIsString($html);
+        $this->assertStringContainsString('Bot 1', $html);
+    }
+
+    public function test_renderEdit_calls_repository_when_botId_provided(): void
+    {
+        $botId = 'test-bot';
+        $this->repositoryMock->expects($this->once())
+            ->method('findBotConfig')
+            ->with($botId)
+            ->willReturn(['bot_name' => 'Test Bot']);
+
+        $html = $this->service->renderEdit($botId);
+        $this->assertIsString($html);
+        $this->assertStringContainsString('Test Bot', $html);
+    }
+
+    public function test_renderTriggers_calls_repository(): void
+    {
+        $botId = 'test-bot';
+        $this->repositoryMock->expects($this->once())
+            ->method('findBotConfig')
+            ->willReturn(['bot_name' => 'Test Bot']);
+        $this->repositoryMock->expects($this->once())
+            ->method('findTriggers')
+            ->with($botId)
+            ->willReturn([['id' => 'trigger_1', 'request' => 'Hello']]);
+
+        $html = $this->service->renderTriggers($botId);
+        $this->assertIsString($html);
+        $this->assertStringContainsString('Test Bot', $html);
+        $this->assertStringContainsString('Hello', $html);
+    }
+
+    public function test_renderTriggerEdit_calls_repository(): void
+    {
+        $botId = 'test-bot';
+        $triggerId = 'trigger-1';
+        $this->repositoryMock->expects($this->once())
+            ->method('findBotConfig')
+            ->willReturn(['bot_name' => 'Test Bot']);
+        $this->repositoryMock->expects($this->once())
+            ->method('findTrigger')
+            ->with($botId, $triggerId)
+            ->willReturn(['id' => $triggerId, 'request' => 'Hello']);
+
+        $html = $this->service->renderTriggerEdit($botId, $triggerId);
+        $this->assertIsString($html);
+        $this->assertStringContainsString('Test Bot', $html);
+        $this->assertStringContainsString('Hello', $html);
+    }
+
+    public function test_saveBotConfig_calls_repository(): void
+    {
+        $botId = 'test-bot';
+        $data = ['bot_name' => 'New Name'];
+        $this->repositoryMock->expects($this->once())
+            ->method('saveBotConfig')
+            ->with($botId, $data);
+
+        $this->service->saveBotConfig($botId, $data);
+    }
+
+    public function test_saveTrigger_calls_repository(): void
+    {
+        $botId = 'test-bot';
+        $triggerId = 'trigger-1';
+        $data = ['request' => 'New Trigger'];
+        $this->repositoryMock->expects($this->once())
+            ->method('saveTrigger')
+            ->with($botId, $triggerId, $data);
+
+        $this->service->saveTrigger($botId, $triggerId, $data);
+    }
+
+    public function test_deleteTrigger_calls_repository(): void
+    {
+        $botId = 'test-bot';
+        $triggerId = 'trigger-1';
+        $this->repositoryMock->expects($this->once())
+            ->method('deleteTrigger')
+            ->with($botId, $triggerId);
+
+        $this->service->deleteTrigger($botId, $triggerId);
+    }
+
+    public function test_deleteBot_calls_repository(): void
+    {
+        $botId = 'test-bot';
+        $this->repositoryMock->expects($this->once())
+            ->method('deleteBot')
+            ->with($botId);
+
+        $this->service->deleteBot($botId);
+    }
+}

--- a/tests/Domain/Bot/ValueObject/MessageTest.php
+++ b/tests/Domain/Bot/ValueObject/MessageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\Bot\ValueObject;
+
+use App\Domain\Bot\ValueObject\Message;
+use PHPUnit\Framework\TestCase;
+
+final class MessageTest extends TestCase
+{
+    public function test_it_stores_content_and_is_system_flag(): void
+    {
+        $message = new Message("Hello world", false);
+        $this->assertSame("Hello world", $message->getContent());
+        $this->assertFalse($message->isSystem());
+
+        $systemMessage = new Message("System alert", true);
+        $this->assertSame("System alert", $systemMessage->getContent());
+        $this->assertTrue($systemMessage->isSystem());
+    }
+
+    public function test_is_system_defaults_to_false(): void
+    {
+        $message = new Message("Default message");
+        $this->assertFalse($message->isSystem());
+    }
+
+    public function test_it_can_be_converted_to_string(): void
+    {
+        $message = new Message("Hello");
+        $this->assertSame("Hello", (string)$message);
+    }
+}

--- a/tests/Domain/Bot/ValueObject/MessageTest.php
+++ b/tests/Domain/Bot/ValueObject/MessageTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class MessageTest extends TestCase
 {
-    public function test_it_stores_content_and_is_system_flag(): void
+    public function test_内容とシステムフラグを保持する(): void
     {
         $message = new Message("Hello world", false);
         $this->assertSame("Hello world", $message->getContent());
@@ -20,13 +20,13 @@ final class MessageTest extends TestCase
         $this->assertTrue($systemMessage->isSystem());
     }
 
-    public function test_is_system_defaults_to_false(): void
+    public function test_システムフラグのデフォルト値がfalseであることを確認する(): void
     {
         $message = new Message("Default message");
         $this->assertFalse($message->isSystem());
     }
 
-    public function test_it_can_be_converted_to_string(): void
+    public function test_文字列に変換できる(): void
     {
         $message = new Message("Hello");
         $this->assertSame("Hello", (string)$message);

--- a/tests/Domain/Config/ConfigTest.php
+++ b/tests/Domain/Config/ConfigTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Domain\Config;
+
+use App\Domain\Config\Config;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    public function test_it_stores_id_and_data(): void
+    {
+        $data = ['key' => 'value'];
+        $config = new Config('bot_123', $data);
+
+        $this->assertSame('bot_123', $config->getId());
+        $this->assertSame($data, $config->getData());
+    }
+
+    public function test_it_can_update_data(): void
+    {
+        $config = new Config('bot_123', ['old' => 'data']);
+        $newData = ['new' => 'data'];
+        $config->setData($newData);
+
+        $this->assertSame($newData, $config->getData());
+    }
+}

--- a/tests/Domain/Config/ConfigTest.php
+++ b/tests/Domain/Config/ConfigTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ConfigTest extends TestCase
 {
-    public function test_it_stores_id_and_data(): void
+    public function test_IDとデータを保持する(): void
     {
         $data = ['key' => 'value'];
         $config = new Config('bot_123', $data);
@@ -18,7 +18,7 @@ final class ConfigTest extends TestCase
         $this->assertSame($data, $config->getData());
     }
 
-    public function test_it_can_update_data(): void
+    public function test_データを更新できる(): void
     {
         $config = new Config('bot_123', ['old' => 'data']);
         $newData = ['new' => 'data'];

--- a/tests/Domain/Exception/DomainExceptionTest.php
+++ b/tests/Domain/Exception/DomainExceptionTest.php
@@ -5,6 +5,8 @@ namespace Tests\Domain\Exception;
 use PHPUnit\Framework\TestCase;
 use App\Domain\Exception\BotNotFoundException;
 use App\Domain\Exception\InvalidWebhookEventException;
+use App\Domain\Exception\HandlerNotFoundException;
+use App\Domain\Exception\TriggerNotFoundException;
 use App\Domain\Exception\DomainException;
 
 final class DomainExceptionTest extends TestCase
@@ -21,5 +23,19 @@ final class DomainExceptionTest extends TestCase
         $exception = new InvalidWebhookEventException("Invalid webhook event");
         $this->assertInstanceOf(DomainException::class, $exception);
         $this->assertEquals("Invalid webhook event", $exception->getMessage());
+    }
+
+    public function test_HandlerNotFoundExceptionはDomainExceptionを継承している(): void
+    {
+        $exception = new HandlerNotFoundException("Handler not found");
+        $this->assertInstanceOf(DomainException::class, $exception);
+        $this->assertEquals("Handler not found", $exception->getMessage());
+    }
+
+    public function test_TriggerNotFoundExceptionはDomainExceptionを継承している(): void
+    {
+        $exception = new TriggerNotFoundException("Trigger not found");
+        $this->assertInstanceOf(DomainException::class, $exception);
+        $this->assertEquals("Trigger not found", $exception->getMessage());
     }
 }


### PR DESCRIPTION
既存のコードベースにおいて不足していた以下のテストコードを追加・修正しました。

- `AppConfig`: 環境変数に応じた設定値（Firestoreコレクション名、ベースパスなど）の取得ロジックのテストを追加。
- `Message` (Value Object): コンストラクタでのデータ保持と文字列変換のテストを追加。
- `Config` (Entity): IDとデータの保持、データの更新ロジックのテストを追加。
- `ConfigApplicationService`: リポジトリとの連携およびBladeOneによるレンダリング結果の検証テストを追加。
- `DomainException`: `HandlerNotFoundException` と `TriggerNotFoundException` が正しく `DomainException` を継承しているかのテストを追加。

保守性を考慮し、`ConfigApplicationServiceTest` ではモックを最小限にし、実際のBladeOneエンジンを使用してテストを行っています。また、PSR-4のディレクトリ構造に従ってファイルを配置しました。

---
*PR created automatically by Jules for task [14546906258214590426](https://jules.google.com/task/14546906258214590426) started by @yananob*