### PR TITLE
Add Chat Logs GUI with Pagination

### DIFF
--- a/src/Application/Config/ConfigApplicationService.php
+++ b/src/Application/Config/ConfigApplicationService.php
@@ -4,6 +4,7 @@ namespace App\Application\Config;
 
 use App\Domain\Bot\BotRepository;
 use App\Domain\Bot\Trigger\TimerTrigger;
+use App\Domain\Conversation\ConversationRepository;
 use eftec\bladeone\BladeOne;
 
 class ConfigApplicationService
@@ -13,6 +14,7 @@ class ConfigApplicationService
 
     public function __construct(
         private BotRepository $botRepository,
+        private ConversationRepository $conversationRepository,
         string $viewsPath,
         string $cachePath
     ) {
@@ -101,6 +103,41 @@ class ConfigApplicationService
             "botId" => $botId,
             "botName" => $bot->getName(),
             "triggers" => $triggersData,
+            "basePath" => $this->basePath
+        ]);
+    }
+
+    public function renderLogs(string $botId, int $page = 1): string
+    {
+        $limit = 50;
+        $offset = ($page - 1) * $limit;
+
+        $bot = ($botId === 'default')
+            ? $this->botRepository->findDefault()
+            : $this->botRepository->findById($botId);
+
+        $conversations = $this->conversationRepository->findByBotId($botId, $limit + 1, $offset);
+
+        $hasMore = count($conversations) > $limit;
+        if ($hasMore) {
+            array_pop($conversations);
+        }
+
+        $logs = [];
+        foreach ($conversations as $conv) {
+            $logs[] = [
+                'speaker' => $conv->getSpeaker(),
+                'content' => $conv->getContent(),
+                'created_at' => $conv->getCreatedAt()->format('Y-m-d H:i:s'),
+            ];
+        }
+
+        return $this->blade->run("config.logs", [
+            "botId" => $botId,
+            "botName" => $bot->getName(),
+            "logs" => $logs,
+            "page" => $page,
+            "hasMore" => $hasMore,
             "basePath" => $this->basePath
         ]);
     }

--- a/src/Domain/Conversation/ConversationRepository.php
+++ b/src/Domain/Conversation/ConversationRepository.php
@@ -10,9 +10,10 @@ interface ConversationRepository
      *
      * @param string $botId The ID of the bot.
      * @param int $limit The maximum number of conversation entries to retrieve.
+     * @param int $offset The number of entries to skip.
      * @return Conversation[] An array of Conversation objects.
      */
-    public function findByBotId(string $botId, int $limit = 20): array;
+    public function findByBotId(string $botId, int $limit = 20, int $offset = 0): array;
 
     /**
      * Saves a Conversation entry.

--- a/src/Infrastructure/DependencyInjection/Container.php
+++ b/src/Infrastructure/DependencyInjection/Container.php
@@ -117,6 +117,7 @@ class Container
         $cachePath = sys_get_temp_dir() . '/bladeone_cache';
         return new \App\Application\Config\ConfigApplicationService(
             $this->getBotRepository(),
+            $this->getConversationRepository(),
             __DIR__ . '/../../../views',
             $cachePath
         );

--- a/src/Infrastructure/Http/BotConfigController.php
+++ b/src/Infrastructure/Http/BotConfigController.php
@@ -61,6 +61,14 @@ class BotConfigController
             }
             return new Response(200, ['Content-Type' => 'text/html'], $this->configService->renderTriggers($botId));
         }
+        if ($subPath === '/logs') {
+            $botId = $request->getQueryParams()['bot_id'] ?? null;
+            $page = (int)($request->getQueryParams()['page'] ?? 1);
+            if (!$botId) {
+                return new Response(302, ['Location' => $basePath . '/config']);
+            }
+            return new Response(200, ['Content-Type' => 'text/html'], $this->configService->renderLogs($botId, $page));
+        }
         if ($subPath === '/trigger/edit') {
             $botId = $request->getQueryParams()['bot_id'] ?? null;
             $triggerId = $request->getQueryParams()['trigger_id'] ?? null;

--- a/src/Infrastructure/Persistence/Firestore/FirestoreConversationRepository.php
+++ b/src/Infrastructure/Persistence/Firestore/FirestoreConversationRepository.php
@@ -27,10 +27,12 @@ class FirestoreConversationRepository extends AbstractFirestoreRepository implem
                         ->collection($botId);
     }
 
-    public function findByBotId(string $botId, int $limit = 20): array
+    public function findByBotId(string $botId, int $limit = 20, int $offset = 0): array
     {
         $conversationsCollection = $this->getBotConversationsCollection($botId);
-        $query = $conversationsCollection->orderBy('createdAt', Query::DIR_DESCENDING)->limit($limit);
+        $query = $conversationsCollection->orderBy('createdAt', Query::DIR_DESCENDING)
+            ->limit($limit)
+            ->offset($offset);
         $documents = $query->documents();
 
         $conversations = [];

--- a/tests/Application/Config/ConfigApplicationServiceTest.php
+++ b/tests/Application/Config/ConfigApplicationServiceTest.php
@@ -8,11 +8,13 @@ use App\Application\Config\ConfigApplicationService;
 use App\Domain\Bot\Bot;
 use App\Domain\Bot\BotRepository;
 use App\Domain\Bot\Trigger\TimerTrigger;
+use App\Domain\Conversation\ConversationRepository;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigApplicationServiceTest extends TestCase
 {
     private $repositoryMock;
+    private $conversationRepositoryMock;
     private ConfigApplicationService $service;
     private string $viewsPath;
     private string $cachePath;
@@ -20,11 +22,13 @@ final class ConfigApplicationServiceTest extends TestCase
     protected function setUp(): void
     {
         $this->repositoryMock = $this->createMock(BotRepository::class);
+        $this->conversationRepositoryMock = $this->createMock(ConversationRepository::class);
         $this->viewsPath = __DIR__ . '/../../../views';
         $this->cachePath = '/tmp/bladeone_cache_test';
 
         $this->service = new ConfigApplicationService(
             $this->repositoryMock,
+            $this->conversationRepositoryMock,
             $this->viewsPath,
             $this->cachePath
         );
@@ -168,5 +172,26 @@ final class ConfigApplicationServiceTest extends TestCase
             ->with($botId);
 
         $this->service->deleteBot($botId);
+    }
+
+    public function test_renderLogsは会話リポジトリを呼び出す(): void
+    {
+        $botId = 'test-bot';
+        $bot = new Bot($botId);
+        $bot->setName('Test Bot');
+
+        $this->repositoryMock->expects($this->once())
+            ->method('findById')
+            ->with($botId)
+            ->willReturn($bot);
+
+        $this->conversationRepositoryMock->expects($this->once())
+            ->method('findByBotId')
+            ->with($botId, 51, 0)
+            ->willReturn([]);
+
+        $html = $this->service->renderLogs($botId, 1);
+        $this->assertIsString($html);
+        $this->assertStringContainsString('Chat Logs: Test Bot', $html);
     }
 }

--- a/tests/Infrastructure/Persistence/Firestore/FirestoreConversationRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/Firestore/FirestoreConversationRepositoryTest.php
@@ -82,6 +82,8 @@ final class FirestoreConversationRepositoryTest extends TestCase // TestCaseã®å
         $this->botConversationsCollRefMock->expects($this->once())
             ->method('limit')->with($limit)->willReturnSelf();
         $this->botConversationsCollRefMock->expects($this->once())
+            ->method('offset')->with(0)->willReturnSelf();
+        $this->botConversationsCollRefMock->expects($this->once())
             ->method('documents')->willReturn(new \ArrayObject([$docSnapshotMock2, $docSnapshotMock1]));
 
         $conversations = $this->repository->findByBotId($botId, $limit);
@@ -161,10 +163,29 @@ final class FirestoreConversationRepositoryTest extends TestCase // TestCaseã®å
         $botId = "emptyBotId";
         $this->botConversationsCollRefMock->method('orderBy')->willReturnSelf();
         $this->botConversationsCollRefMock->method('limit')->willReturnSelf();
+        $this->botConversationsCollRefMock->method('offset')->willReturnSelf();
         $this->botConversationsCollRefMock->method('documents')->willReturn(new \ArrayObject([]));
 
         $conversations = $this->repository->findByBotId($botId);
         $this->assertCount(0, $conversations);
         $this->assertEquals([], $conversations);
+    }
+
+    public function test_findByBotId_with_offset(): void
+    {
+        $botId = "testBotId";
+        $limit = 10;
+        $offset = 20;
+
+        $this->botConversationsCollRefMock->expects($this->once())
+            ->method('orderBy')->with('createdAt', Query::DIR_DESCENDING)->willReturnSelf();
+        $this->botConversationsCollRefMock->expects($this->once())
+            ->method('limit')->with($limit)->willReturnSelf();
+        $this->botConversationsCollRefMock->expects($this->once())
+            ->method('offset')->with($offset)->willReturnSelf();
+        $this->botConversationsCollRefMock->expects($this->once())
+            ->method('documents')->willReturn(new \ArrayObject([]));
+
+        $this->repository->findByBotId($botId, $limit, $offset);
     }
 }

--- a/views/config/index.blade.php
+++ b/views/config/index.blade.php
@@ -25,6 +25,7 @@
                 <td>
                     <a href="{{ $basePath }}/config/edit?bot_id={{ $botId }}" class="btn btn-xs btn-primary">Edit Config</a>
                     <a href="{{ $basePath }}/config/triggers?bot_id={{ $botId }}" class="btn btn-xs btn-outline-info">Triggers</a>
+                    <a href="{{ $basePath }}/config/logs?bot_id={{ $botId }}" class="btn btn-xs btn-outline-secondary">Logs</a>
                     <form action="{{ $basePath }}/config/delete" method="POST" style="display:inline-block;" onsubmit="return confirm('Delete Bot {{ $botData['bot_name'] ?? $botId }}?');">
                         <input type="hidden" name="bot_id" value="{{ $botId }}">
                         <button type="submit" class="btn btn-xs btn-danger">Delete</button>

--- a/views/config/logs.blade.php
+++ b/views/config/logs.blade.php
@@ -1,0 +1,70 @@
+@extends('layout')
+
+@section('title', 'Chat Logs - ' . ($botName ?: $botId))
+
+@section('content')
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">Chat Logs: {{ $botName ?: $botId }}</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <a href="{{ $basePath }}/config" class="btn btn-sm btn-outline-secondary">Back to List</a>
+    </div>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-striped table-sm">
+        <thead>
+            <tr>
+                <th scope="col" style="width: 150px;">Time</th>
+                <th scope="col" style="width: 100px;">Speaker</th>
+                <th scope="col">Content</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($logs as $log)
+            <tr>
+                <td>{{ $log['created_at'] }}</td>
+                <td>
+                    <span class="badge {{ $log['speaker'] === 'bot' ? 'bg-primary' : 'bg-secondary' }}">
+                        {{ $log['speaker'] }}
+                    </span>
+                </td>
+                <td style="white-space: pre-wrap;">{{ $log['content'] }}</td>
+            </tr>
+            @endforeach
+            @if(empty($logs))
+            <tr>
+                <td colspan="3" class="text-center">No logs found.</td>
+            </tr>
+            @endif
+        </tbody>
+    </table>
+</div>
+
+<nav aria-label="Page navigation">
+    <ul class="pagination justify-content-center">
+        @if($page > 1)
+        <li class="page-item">
+            <a class="page-link" href="{{ $basePath }}/config/logs?bot_id={{ $botId }}&page={{ $page - 1 }}">Previous</a>
+        </li>
+        @else
+        <li class="page-item disabled">
+            <span class="page-link">Previous</span>
+        </li>
+        @endif
+
+        <li class="page-item disabled">
+            <span class="page-link">Page {{ $page }}</span>
+        </li>
+
+        @if($hasMore)
+        <li class="page-item">
+            <a class="page-link" href="{{ $basePath }}/config/logs?bot_id={{ $botId }}&page={{ $page + 1 }}">Next</a>
+        </li>
+        @else
+        <li class="page-item disabled">
+            <span class="page-link">Next</span>
+        </li>
+        @endif
+    </ul>
+</nav>
+@endsection


### PR DESCRIPTION
This change allows users to view chat logs for each bot through the web-based configuration interface. It includes support for pagination (50 entries per page) to handle cases where there are a large number of logs. The UI displays the speaker, message content, and timestamp in a readable format.

---
*PR created automatically by Jules for task [3618566220613481985](https://jules.google.com/task/3618566220613481985) started by @yananob*