### PR TITLE
Refactor Bot and Trigger instantiation using Factory pattern

### DIFF
--- a/src/Domain/Bot/Service/BotFactory.php
+++ b/src/Domain/Bot/Service/BotFactory.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace App\Domain\Bot\Service;
+
+use App\Domain\Bot\Bot;
+use App\Domain\Bot\Trigger\Trigger;
+
+class BotFactory
+{
+    /**
+     * @param string $id
+     * @param array<string, mixed> $data
+     * @param array<string, Trigger> $triggers
+     * @param Bot|null $defaultBot
+     * @return Bot
+     */
+    public static function create(
+        string $id,
+        array $data,
+        array $triggers = [],
+        ?Bot $defaultBot = null
+    ): Bot {
+        $bot = new Bot($id, $defaultBot);
+        $bot->setName($data['bot_name'] ?? '');
+        $bot->setBotCharacteristics($data['bot_characteristics'] ?? []);
+        $bot->setHumanCharacteristics($data['human_characteristics'] ?? []);
+        $bot->setConfigRequests($data['requests'] ?? []);
+        $bot->setLineTarget($data['line_target'] ?? '');
+        $bot->setTriggers($triggers);
+
+        return $bot;
+    }
+}

--- a/src/Domain/Bot/Trigger/TriggerFactory.php
+++ b/src/Domain/Bot/Trigger/TriggerFactory.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace App\Domain\Bot\Trigger;
+
+class TriggerFactory
+{
+    /**
+     * @param string $id
+     * @param array<string, mixed> $data
+     * @return Trigger|null
+     */
+    public static function fromArray(string $id, array $data): ?Trigger
+    {
+        if (isset($data['event']) && $data['event'] === 'timer') {
+            $date = (string)($data['date'] ?? '');
+            $time = (string)($data['time'] ?? '');
+            $request = (string)($data['request'] ?? '');
+            $trigger = new TimerTrigger($date, $time, $request);
+            $trigger->setId($id);
+            return $trigger;
+        }
+
+        return null;
+    }
+}

--- a/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
+++ b/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
@@ -8,8 +8,8 @@ use Google\Cloud\Firestore\CollectionReference;
 use Google\Cloud\Firestore\DocumentSnapshot;
 use App\Domain\Bot\Bot;
 use App\Domain\Bot\BotRepository;
-use App\Domain\Bot\Trigger\TimerTrigger;
-use App\Domain\Bot\Trigger\Trigger;
+use App\Domain\Bot\Service\BotFactory;
+use App\Domain\Bot\Trigger\TriggerFactory;
 use App\Domain\Exception\BotNotFoundException;
 
 class FirestoreBotRepository extends AbstractFirestoreRepository implements BotRepository
@@ -36,34 +36,19 @@ class FirestoreBotRepository extends AbstractFirestoreRepository implements BotR
             return null;
         }
 
-        $bot = new Bot($botId, $defaultBotConfig);
         $data = $configSnapshot->data();
-
-        $bot->setName($data['bot_name'] ?? '');
-        $bot->setBotCharacteristics($data['bot_characteristics'] ?? []);
-        $bot->setHumanCharacteristics($data['human_characteristics'] ?? []);
-        $bot->setConfigRequests($data['requests'] ?? []);
-        $bot->setLineTarget($data['line_target'] ?? '');
 
         // Load triggers
         $triggerDocs = $this->getBotCollection($botId)->document('triggers')->collection('triggers')->documents();
         $triggers = [];
         foreach ($triggerDocs as $doc) {
-            $id = $doc->id();
-            $tData = $doc->data();
-            // Assuming TimerTrigger for now, this would need to be more flexible
-            if (isset($tData['event']) && $tData['event'] === 'timer') {
-                $dateForTrigger = (string)($tData['date'] ?? '');
-                $timeForTrigger = (string)($tData['time'] ?? '');
-                $request = (string)($tData['request'] ?? '');
-                $trigger = new TimerTrigger($dateForTrigger, $timeForTrigger, $request);
-                $trigger->setId((string)$id);
+            $trigger = TriggerFactory::fromArray((string)$doc->id(), $doc->data());
+            if ($trigger !== null) {
                 $triggers[$trigger->getId()] = $trigger;
             }
         }
-        $bot->setTriggers($triggers);
 
-        return $bot;
+        return BotFactory::create($botId, $data, $triggers, $defaultBotConfig);
     }
 
     public function findById(string $id): Bot

--- a/tests/Domain/Bot/Service/BotFactoryTest.php
+++ b/tests/Domain/Bot/Service/BotFactoryTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Domain\Bot\Service;
+
+use PHPUnit\Framework\TestCase;
+use App\Domain\Bot\Bot;
+use App\Domain\Bot\Service\BotFactory;
+use App\Domain\Bot\Trigger\TimerTrigger;
+
+class BotFactoryTest extends TestCase
+{
+    public function testCreateBot(): void
+    {
+        $id = 'bot_123';
+        $data = [
+            'bot_name' => 'Test Bot',
+            'bot_characteristics' => ['Friendly'],
+            'human_characteristics' => ['Helpful'],
+            'requests' => ['Say hello'],
+            'line_target' => 'target_123'
+        ];
+        $trigger = new TimerTrigger('today', '10:00', 'Ping');
+        $trigger->setId('t1');
+        $triggers = ['t1' => $trigger];
+
+        $bot = BotFactory::create($id, $data, $triggers);
+
+        $this->assertInstanceOf(Bot::class, $bot);
+        $this->assertSame($id, $bot->getId());
+        $this->assertSame('Test Bot', $bot->getName());
+        $this->assertSame(['Friendly'], $bot->getBotCharacteristics()->toArray());
+        $this->assertSame(['Helpful'], $bot->getHumanCharacteristics()->toArray());
+        $this->assertSame(['Say hello'], $bot->getConfigRequests(true, false)->toArray());
+        $this->assertSame('target_123', $bot->getLineTarget());
+        $this->assertSame($triggers, $bot->getTriggers());
+    }
+
+    public function testCreateBotWithDefaultBot(): void
+    {
+        $defaultBot = new Bot('default');
+        $defaultBot->setBotCharacteristics(['Base']);
+
+        $id = 'bot_123';
+        $data = [
+            'bot_characteristics' => ['Extra'],
+        ];
+
+        $bot = BotFactory::create($id, $data, [], $defaultBot);
+
+        // getBotCharacteristics merges by default
+        $this->assertSame(['Base', 'Extra'], $bot->getBotCharacteristics()->toArray());
+    }
+}

--- a/tests/Domain/Bot/Trigger/TriggerFactoryTest.php
+++ b/tests/Domain/Bot/Trigger/TriggerFactoryTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Domain\Bot\Trigger;
+
+use PHPUnit\Framework\TestCase;
+use App\Domain\Bot\Trigger\TriggerFactory;
+use App\Domain\Bot\Trigger\TimerTrigger;
+
+class TriggerFactoryTest extends TestCase
+{
+    public function testFromArrayWithTimerEvent(): void
+    {
+        $id = 'trigger_123';
+        $data = [
+            'event' => 'timer',
+            'date' => '2023-12-25',
+            'time' => '12:00',
+            'request' => 'Hello'
+        ];
+
+        $trigger = TriggerFactory::fromArray($id, $data);
+
+        $this->assertInstanceOf(TimerTrigger::class, $trigger);
+        $this->assertSame($id, $trigger->getId());
+        $this->assertSame('2023-12-25', $trigger->getDate());
+        $this->assertSame('12:00', $trigger->getTime());
+        $this->assertSame('Hello', $trigger->getRequest());
+    }
+
+    public function testFromArrayWithUnknownEvent(): void
+    {
+        $id = 'trigger_123';
+        $data = [
+            'event' => 'unknown',
+        ];
+
+        $trigger = TriggerFactory::fromArray($id, $data);
+
+        $this->assertNull($trigger);
+    }
+
+    public function testFromArrayWithMissingEvent(): void
+    {
+        $id = 'trigger_123';
+        $data = [
+            'date' => '2023-12-25',
+        ];
+
+        $trigger = TriggerFactory::fromArray($id, $data);
+
+        $this->assertNull($trigger);
+    }
+}


### PR DESCRIPTION
This PR improves maintainability by separating domain object construction from the persistence layer. It introduces `BotFactory` and `TriggerFactory` to handle the instantiation of `Bot` and `Trigger` aggregates from raw data, reducing the responsibility of `FirestoreBotRepository`.

---
*PR created automatically by Jules for task [6081091095977133636](https://jules.google.com/task/6081091095977133636) started by @yananob*