### PR TITLE
Improve Test Robustness and GPT Response Parsing

### DIFF
--- a/src/Domain/Bot/Service/CommandAndTriggerService.php
+++ b/src/Domain/Bot/Service/CommandAndTriggerService.php
@@ -76,7 +76,7 @@ EOM;
 
     public function judgeCommand(string $message): Command
     {
-        $result = $this->gpt->getAnswer(self::PROMPT_JUDGE_COMMAND, $message);
+        $result = trim($this->gpt->getAnswer(self::PROMPT_JUDGE_COMMAND, $message));
         try {
             // Assuming Command::from() is a method that can handle string values.
             // If Command is an enum, this might need adjustment based on PHP version.
@@ -101,7 +101,7 @@ EOM;
 
     private function __generateTimerTrigger(string $prompt, string $message): TimerTrigger
     {
-        $result = $this->gpt->getAnswer($prompt, $message);
+        $result = trim($this->gpt->getAnswer($prompt, $message));
 
         // Default values in case regex fails
         $date = "today";
@@ -110,17 +110,17 @@ EOM;
 
         $matchesDate = [];
         if (preg_match('/・日付：(.+)$/m', $result, $matchesDate)) {
-            $date = rtrim($matchesDate[1]);
+            $date = trim($matchesDate[1]);
         }
 
         $matchesTime = [];
         if (preg_match('/・時刻：(.+)$/m', $result, $matchesTime)) {
-            $time = rtrim($matchesTime[1]);
+            $time = trim($matchesTime[1]);
         }
         
         $matchesRequest = [];
         if (preg_match('/・依頼内容：(.+)$/m', $result, $matchesRequest)) {
-            $request = rtrim($matchesRequest[1]);
+            $request = trim($matchesRequest[1]);
         }
 
         return new TimerTrigger($date, $time, $request);

--- a/tests/Application/ChatApplicationServiceTest.php
+++ b/tests/Application/ChatApplicationServiceTest.php
@@ -41,9 +41,20 @@ final class ChatApplicationServiceTest extends TestCase
         );
     }
 
-    public function test_handleMessage_delegates_to_handler(): void
+    public function test_handleMessage_delegates_to_handler_and_logs(): void
     {
+        $loggerMock = $this->createMock(\App\Infrastructure\Logger\Logger::class);
+        $chatService = new ChatApplicationService(
+            $this->bot,
+            $this->commandAndTriggerServiceMock,
+            [$this->messageHandlerMock],
+            [$this->postbackHandlerMock],
+            $loggerMock
+        );
+
         $this->commandAndTriggerServiceMock->method('judgeCommand')->willReturn(Command::Other);
+        $loggerMock->expects($this->once())->method('log')->with($this->stringContains('Judged Command: 9'));
+
         $this->messageHandlerMock->method('canHandle')->with(Command::Other)->willReturn(true);
         $this->messageHandlerMock->expects($this->once())
             ->method('handle')
@@ -52,7 +63,7 @@ final class ChatApplicationServiceTest extends TestCase
             }), $this->bot, Command::Other)
             ->willReturn(new BotResponse("hi"));
 
-        $response = $this->chatService->handleMessage("hello");
+        $response = $chatService->handleMessage("hello");
         $this->assertSame("hi", $response->getText());
     }
 

--- a/tests/Application/CommandHandler/DefaultChatHandlerTest.php
+++ b/tests/Application/CommandHandler/DefaultChatHandlerTest.php
@@ -57,23 +57,40 @@ final class DefaultChatHandlerTest extends TestCase
         $this->assertSame("world", $response->getText());
     }
 
-    public function test_handle_withWebSearch(): void
+    /**
+     * @dataProvider provideWebSearchJudgmentCases
+     */
+    public function test_handle_withWebSearch(string $gptJudgment, bool $shouldSearch): void
     {
         $handler = new DefaultChatHandler($this->gptMock, $this->convRepoMock, $this->promptService, $this->webSearchMock);
         $bot = new Bot("test");
 
-        $this->gptMock->method('getAnswer')->willReturnCallback(function($context, $message) {
+        $this->gptMock->method('getAnswer')->willReturnCallback(function($context, $message) use ($gptJudgment) {
             if ($context === Messages::PROMPT_JUDGE_WEB_SEARCH) {
-                return "はい";
+                return $gptJudgment;
             }
-            return "Answer with web results";
+            return "Final Answer";
         });
 
-        $this->webSearchMock->expects($this->once())->method('search')->willReturn("Web info");
+        if ($shouldSearch) {
+            $this->webSearchMock->expects($this->once())->method('search')->willReturn("Web info");
+        } else {
+            $this->webSearchMock->expects($this->never())->method('search');
+        }
 
         $message = new Message("search query", false);
         $response = $handler->handle($message, $bot, Command::Other);
-        $this->assertSame("Answer with web results", $response->getText());
+        $this->assertSame("Final Answer", $response->getText());
+    }
+
+    public static function provideWebSearchJudgmentCases(): array
+    {
+        return [
+            'Normal Yes' => ["はい", true],
+            'Yes with whitespace' => [" はい \n", true],
+            'Normal No' => ["いいえ", false],
+            'Other response' => ["わからない", false],
+        ];
     }
 
     public function test_handle_systemTriggerMessageIsNotStored(): void

--- a/tests/Domain/Bot/Service/CommandAndTriggerServiceTest.php
+++ b/tests/Domain/Bot/Service/CommandAndTriggerServiceTest.php
@@ -50,6 +50,7 @@ final class CommandAndTriggerServiceTest extends \PHPUnit\Framework\TestCase // 
             ["未知のコマンド", "9", Command::Other],
             ["GPTが数字以外を返した場合", "unexpected_string", Command::Other], // 堅牢性テスト
             ["GPTが空文字を返した場合", "", Command::Other], // 堅牢性テスト
+            ["GPTの回答に空白が含まれる場合", " 3 \n", Command::AddOneTimeTrigger], // 堅牢性テスト
         ];
     }
 
@@ -98,6 +99,12 @@ final class CommandAndTriggerServiceTest extends \PHPUnit\Framework\TestCase // 
                 "不完全なメッセージ",
                 "・日付：today\n・時刻：", // 時刻と依頼内容が欠落
                 ['date' => "today", 'time' => "now", 'request' => "Could not parse request"] // サービスからのデフォルト値
+            ],
+            [
+                // 堅牢性テスト: GPTの回答に余計な空白や改行が含まれる
+                "空白ありメッセージ",
+                "\n ・日付： today \n ・時刻： 12:00 \n ・依頼内容： テスト \n",
+                ['date' => "today", 'time' => "12:00", 'request' => "テスト"]
             ],
         ];
     }

--- a/tests/Infrastructure/Line/LineClientTest.php
+++ b/tests/Infrastructure/Line/LineClientTest.php
@@ -70,6 +70,40 @@ final class LineClientTest extends TestCase
         $client->sendReply('bot1', 'token', 'reply');
     }
 
+    public function test_sendReply_with_quickReply_calls_messaging_api_with_correct_parameters(): void
+    {
+        $apiMock = $this->createMock(MessagingApiApi::class);
+
+        $quickReplyItems = [
+            ['type' => 'action', 'action' => ['type' => 'message', 'label' => 'label', 'text' => 'text']]
+        ];
+
+        $apiMock->expects($this->once())
+            ->method('replyMessage')
+            ->with($this->callback(function (ReplyMessageRequest $request) use ($quickReplyItems) {
+                /** @var TextMessage $message */
+                $message = $request->getMessages()[0];
+                $quickReply = $message->getQuickReply();
+                return $request->getReplyToken() === 'token'
+                    && $message->getText() === 'reply'
+                    && $quickReply !== null
+                    && count($quickReply->getItems()) === 1;
+            }));
+
+        $client = new class($this->tokens, $this->targets, $apiMock) extends LineClient {
+            private $mockApi;
+            public function __construct($tokens, $targets, $mockApi) {
+                parent::__construct($tokens, $targets);
+                $this->mockApi = $mockApi;
+            }
+            protected function getApi(string $bot): MessagingApiApi {
+                return $this->mockApi;
+            }
+        };
+
+        $client->sendReply('bot1', 'token', 'reply', $quickReplyItems);
+    }
+
     public function test_showLoading_calls_messaging_api_with_correct_parameters(): void
     {
         $apiMock = $this->createMock(MessagingApiApi::class);


### PR DESCRIPTION
This PR improves the robustness of the application's test suite and its handling of GPT responses. Key improvements include:

1.  **Robust Parsing**: Updated `CommandAndTriggerService` to use `trim()` on all GPT-generated strings before processing them with regex or enum mapping. This prevents failures caused by leading/trailing whitespace or newlines often present in LLM outputs.
2.  **Expanded Test Coverage**:
    -   Added data-driven tests for `CommandAndTriggerService` and `DefaultChatHandler` to verify correct behavior with varied GPT response formats.
    -   Added infrastructure-level verification for `LineClient` to ensure `quickReplyItems` are correctly passed to the LINE Messaging API.
    -   Verified observability by adding assertions for command judgment logging in `ChatApplicationService`.
3.  **Code Quality**: Refactored existing tests to use PHPUnit data providers where appropriate, improving maintainability and readability.

All 227 tests in the suite are passing.

---
*PR created automatically by Jules for task [15835115147922824567](https://jules.google.com/task/15835115147922824567) started by @yananob*