### PR TITLE
Refactor command dispatching logic

### DIFF
--- a/src/Application/ChatApplicationService.php
+++ b/src/Application/ChatApplicationService.php
@@ -7,8 +7,7 @@ use App\Domain\Bot\Service\CommandAndTriggerService;
 use App\Domain\Bot\ValueObject\Command;
 use App\Domain\Bot\Trigger\TimerTrigger;
 use App\Infrastructure\Gcp\CloudFunctionUtils;
-use App\Application\CommandHandler\CommandHandlerInterface;
-use App\Application\CommandHandler\PostbackHandlerInterface;
+use App\Application\CommandHandler\CommandHandlerDispatcher;
 use App\Domain\Bot\ValueObject\Message;
 use App\Domain\Bot\Messages;
 use App\Domain\Exception\HandlerNotFoundException;
@@ -18,30 +17,18 @@ class ChatApplicationService
 {
     private CommandAndTriggerService $commandAndTriggerService;
     private Bot $bot;
-    /** @var CommandHandlerInterface[] */
-    private array $messageHandlers;
-    /** @var PostbackHandlerInterface[] */
-    private array $postbackHandlers;
+    private CommandHandlerDispatcher $dispatcher;
     private ?Logger $logger;
 
-    /**
-     * @param Bot $bot
-     * @param CommandAndTriggerService $commandAndTriggerService
-     * @param CommandHandlerInterface[] $messageHandlers
-     * @param PostbackHandlerInterface[] $postbackHandlers
-     * @param Logger|null $logger
-     */
     public function __construct(
         Bot $bot,
         CommandAndTriggerService $commandAndTriggerService,
-        array $messageHandlers = [],
-        array $postbackHandlers = [],
+        CommandHandlerDispatcher $dispatcher,
         ?Logger $logger = null
     ) {
         $this->bot = $bot;
         $this->commandAndTriggerService = $commandAndTriggerService;
-        $this->messageHandlers = $messageHandlers;
-        $this->postbackHandlers = $postbackHandlers;
+        $this->dispatcher = $dispatcher;
         $this->logger = $logger;
     }
 
@@ -53,13 +40,7 @@ class ChatApplicationService
         }
         $message = new Message($messageContent, isSystem: false);
 
-        foreach ($this->messageHandlers as $handler) {
-            if ($handler->canHandle($command)) {
-                return $handler->handle($message, $this->bot, $command);
-            }
-        }
-
-        throw new HandlerNotFoundException("No handler found for command: " . $command->value);
+        return $this->dispatcher->dispatchMessage($command, $message, $this->bot);
     }
 
     public function handleTrigger(TimerTrigger $trigger): BotResponse
@@ -70,13 +51,7 @@ class ChatApplicationService
         $message = new Message($messageContent, isSystem: true);
         $command = Command::Other;
 
-        foreach ($this->messageHandlers as $handler) {
-            if ($handler->canHandle($command)) {
-                return $handler->handle($message, $this->bot, $command);
-            }
-        }
-
-        throw new HandlerNotFoundException("No handler found for command: " . $command->value);
+        return $this->dispatcher->dispatchMessage($command, $message, $this->bot);
     }
 
     public function handlePostback(string $data): BotResponse
@@ -84,13 +59,7 @@ class ChatApplicationService
         parse_str($data, $params);
         $command = $params["command"] ?? "";
 
-        foreach ($this->postbackHandlers as $handler) {
-            if ($handler->canHandle($command)) {
-                return $handler->handle($params, $this->bot);
-            }
-        }
-
-        throw new HandlerNotFoundException("Unsupported postback command: " . $command);
+        return $this->dispatcher->dispatchPostback($command, $params, $this->bot);
     }
 
     public function getLineTarget(): string

--- a/src/Application/CommandHandler/CommandHandlerDispatcher.php
+++ b/src/Application/CommandHandler/CommandHandlerDispatcher.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\CommandHandler;
+
+use App\Application\BotResponse;
+use App\Domain\Bot\Bot;
+use App\Domain\Bot\ValueObject\Command;
+use App\Domain\Bot\ValueObject\Message;
+use App\Domain\Exception\HandlerNotFoundException;
+
+class CommandHandlerDispatcher
+{
+    /** @var CommandHandlerInterface[] */
+    private array $messageHandlers;
+    /** @var PostbackHandlerInterface[] */
+    private array $postbackHandlers;
+
+    /**
+     * @param CommandHandlerInterface[] $messageHandlers
+     * @param PostbackHandlerInterface[] $postbackHandlers
+     */
+    public function __construct(array $messageHandlers, array $postbackHandlers)
+    {
+        $this->messageHandlers = $messageHandlers;
+        $this->postbackHandlers = $postbackHandlers;
+    }
+
+    /**
+     * @param Command $command
+     * @param Message $message
+     * @param Bot $bot
+     * @return BotResponse
+     * @throws HandlerNotFoundException
+     */
+    public function dispatchMessage(Command $command, Message $message, Bot $bot): BotResponse
+    {
+        foreach ($this->messageHandlers as $handler) {
+            if ($handler->canHandle($command)) {
+                return $handler->handle($message, $bot, $command);
+            }
+        }
+
+        throw new HandlerNotFoundException("No handler found for command: " . $command->value);
+    }
+
+    /**
+     * @param string $commandValue
+     * @param array<string, mixed> $params
+     * @param Bot $bot
+     * @return BotResponse
+     * @throws HandlerNotFoundException
+     */
+    public function dispatchPostback(string $commandValue, array $params, Bot $bot): BotResponse
+    {
+        foreach ($this->postbackHandlers as $handler) {
+            if ($handler->canHandle($commandValue)) {
+                return $handler->handle($params, $bot);
+            }
+        }
+
+        throw new HandlerNotFoundException("Unsupported postback command: " . $commandValue);
+    }
+}

--- a/src/Infrastructure/DependencyInjection/Container.php
+++ b/src/Infrastructure/DependencyInjection/Container.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\DependencyInjection;
 
 use App\Application\ChatApplicationService;
+use App\Application\CommandHandler\CommandHandlerDispatcher;
 use App\Application\CommandHandler\CommandHandlerFactory;
 use App\Domain\Bot\Bot;
 use App\Domain\Bot\Service\ChatPromptService;
@@ -134,12 +135,12 @@ class Container
             $this->getWebSearchTool()
         );
         $postbackHandlers = CommandHandlerFactory::createPostbackHandlers($this->getBotRepository());
+        $dispatcher = new CommandHandlerDispatcher($messageHandlers, $postbackHandlers);
 
         return new ChatApplicationService(
             $bot,
             $this->getCommandAndTriggerService(),
-            $messageHandlers,
-            $postbackHandlers,
+            $dispatcher,
             $this->getLogger()
         );
     }

--- a/tests/Application/ChatApplicationServiceTest.php
+++ b/tests/Application/ChatApplicationServiceTest.php
@@ -14,6 +14,7 @@ use App\Domain\Bot\Trigger\TimerTrigger;
 use App\Domain\Bot\ValueObject\Message;
 use App\Application\CommandHandler\CommandHandlerInterface;
 use App\Application\CommandHandler\PostbackHandlerInterface;
+use App\Application\CommandHandler\CommandHandlerDispatcher;
 use PHPUnit\Framework\TestCase;
 
 final class ChatApplicationServiceTest extends TestCase
@@ -32,23 +33,23 @@ final class ChatApplicationServiceTest extends TestCase
         $this->commandAndTriggerServiceMock = $this->createMock(CommandAndTriggerService::class);
         $this->messageHandlerMock = $this->createMock(CommandHandlerInterface::class);
         $this->postbackHandlerMock = $this->createMock(PostbackHandlerInterface::class);
+        $dispatcher = new CommandHandlerDispatcher([$this->messageHandlerMock], [$this->postbackHandlerMock]);
 
         $this->chatService = new ChatApplicationService(
             $this->bot,
             $this->commandAndTriggerServiceMock,
-            [$this->messageHandlerMock],
-            [$this->postbackHandlerMock]
+            $dispatcher
         );
     }
 
     public function test_handleMessage_delegates_to_handler_and_logs(): void
     {
         $loggerMock = $this->createMock(\App\Infrastructure\Logger\Logger::class);
+        $dispatcher = new CommandHandlerDispatcher([$this->messageHandlerMock], [$this->postbackHandlerMock]);
         $chatService = new ChatApplicationService(
             $this->bot,
             $this->commandAndTriggerServiceMock,
-            [$this->messageHandlerMock],
-            [$this->postbackHandlerMock],
+            $dispatcher,
             $loggerMock
         );
 
@@ -78,11 +79,11 @@ final class ChatApplicationServiceTest extends TestCase
             ->method('handle')
             ->willReturn(new BotResponse("help content"));
 
+        $dispatcher = new CommandHandlerDispatcher([$handler1, $handler2], []);
         $chatService = new ChatApplicationService(
             $this->bot,
             $this->commandAndTriggerServiceMock,
-            [$handler1, $handler2],
-            []
+            $dispatcher
         );
 
         $this->commandAndTriggerServiceMock->method('judgeCommand')->willReturn(Command::ShowHelp);


### PR DESCRIPTION
This refactoring introduces a dedicated `CommandHandlerDispatcher` to handle the selection and execution of command handlers. Previously, `ChatApplicationService` contained duplicated iteration logic for finding handlers in `handleMessage`, `handleTrigger`, and `handlePostback`. 

By extracting this responsibility:
1. `ChatApplicationService` is now focused purely on orchestration.
2. Handler selection logic is centralized, making it easier to modify or extend (e.g., adding logging or different dispatching strategies) without bloating the service.
3. Code duplication is reduced.

The changes include the new dispatcher class, updates to the application service and its dependency injection setup, and corresponding test updates.

---
*PR created automatically by Jules for task [5067562321389005584](https://jules.google.com/task/5067562321389005584) started by @yananob*