### PR TITLE
AIモデルをGPT-5.4 Miniに変更

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,6 +4,16 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Pull all",
+            "type": "shell",
+            "command": "git pull --all --rebase"
+        },
+        {
+            "label": "run_linter",
+            "type": "shell",
+            "command": "./tests/run_linter.sh"
+        },
+        {
             "label": "run_tests",
             "type": "shell",
             "command": "./tests/run_tests.sh"

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ LINE Messaging APIを使用したAIボットアプリケーションです。Goo
 ## 機能内容
 
 1.  **LINE Bot機能**
-    - ユーザーからのテキストメッセージに対して、GPT-4o（デフォルト）を使用して応答を生成します。
+    - ユーザーからのテキストメッセージに対して、GPT-5.4-mini（デフォルト）を使用して応答を生成します。
     - LINEのクイックリプライを使用して、タイマートリガーの設定などのアクションを促します。
-    - ウェブ検索が必要と判断された場合、OpenAIのウェブ検索ツール（gpt-5-miniなど）を使用して情報を取得し、回答に反映させます。
+    - ウェブ検索が必要と判断された場合、OpenAIのウェブ検索ツール（gpt-5.4-miniなど）を使用して情報を取得し、回答に反映させます。
 
 2.  **スケジューリング機能（タイマートリガー）**
     - 特定の日時にボットからメッセージを送信するように予約できます。
@@ -31,7 +31,7 @@ LINE Messaging APIを使用したAIボットアプリケーションです。Goo
 - **Language**: PHP 8.3/8.4
 - **Framework**: Google Cloud Functions Framework for PHP
 - **Database**: Google Cloud Firestore
-- **AI Integration**: OpenAI API (GPT-4o, Web Search)
+- **AI Integration**: OpenAI API (GPT-5.4-mini, Web Search)
 - **Messaging**: LINE Messaging API
 - **View**: BladeOne, Bootstrap 5
 - **DI**: 独自実装の `Container` クラスによる依存注入

--- a/src/Infrastructure/DependencyInjection/Container.php
+++ b/src/Infrastructure/DependencyInjection/Container.php
@@ -80,7 +80,7 @@ class Container
         if ($this->gptClient === null) {
             $openaiApiKey = getenv("OPENAI_KEY_LINE_AI_BOT") ?: 'dummy';
             $openaiClient = OpenAI::client($openaiApiKey);
-            $this->gptClient = new OpenAiGptClient($openaiClient, "gpt-4o", $this->getLogger());
+            $this->gptClient = new OpenAiGptClient($openaiClient, "gpt-5.4-mini", $this->getLogger());
         }
         return $this->gptClient;
     }
@@ -100,7 +100,7 @@ class Container
             if ($openaiApiKey !== 'dummy') {
                 $openaiClient = OpenAI::client($openaiApiKey);
                 try {
-                    $this->webSearchTool = new OpenAIWebSearchTool($openaiClient, "gpt-5-mini");
+                    $this->webSearchTool = new OpenAIWebSearchTool($openaiClient, "gpt-5.4-mini");
                 } catch (\Exception $e) {
                     // Log error if needed, but return null as it's optional
                     error_log("Failed to initialize WebSearchTool: " . $e->getMessage());

--- a/tests/Infrastructure/Gpt/OpenAiGptClientTest.php
+++ b/tests/Infrastructure/Gpt/OpenAiGptClientTest.php
@@ -21,7 +21,7 @@ final class OpenAiGptClientTest extends TestCase
         $clientMock->method('chat')->willReturn($chatMock);
 
         $expectedPayload = [
-            'model' => 'gpt-4o',
+            'model' => 'gpt-5.4-mini',
             'messages' => [
                 ['role' => 'system', 'content' => 'system context'],
                 ['role' => 'user', 'content' => 'user message'],
@@ -36,7 +36,7 @@ final class OpenAiGptClientTest extends TestCase
             'id' => 'chatcmpl-123',
             'object' => 'chat.completion',
             'created' => 1677652288,
-            'model' => 'gpt-4o',
+            'model' => 'gpt-5.4-mini',
             'choices' => [
                 [
                     'index' => 0,
@@ -59,7 +59,7 @@ final class OpenAiGptClientTest extends TestCase
         /** @var array{x-request-id: string[], openai-model: string[], openai-organization: string[], openai-version: string[], openai-processing-ms: string[], x-ratelimit-limit-requests: string[], x-ratelimit-remaining-requests: string[], x-ratelimit-reset-requests: string[], x-ratelimit-limit-tokens: string[], x-ratelimit-remaining-tokens: string[], x-ratelimit-reset-tokens: string[]} $headers */
         $headers = [
             'x-request-id' => ['req_123'],
-            'openai-model' => ['gpt-4o'],
+            'openai-model' => ['gpt-5.4-mini'],
             'openai-organization' => ['org-123'],
             'openai-version' => ['2020-10-01'],
             'openai-processing-ms' => ['100'],
@@ -78,7 +78,7 @@ final class OpenAiGptClientTest extends TestCase
             ->with($expectedPayload)
             ->willReturn($response);
 
-        $gptClient = new OpenAiGptClient($clientMock, 'gpt-4o');
+        $gptClient = new OpenAiGptClient($clientMock, 'gpt-5.4-mini');
         $answer = $gptClient->getAnswer('system context', 'user message', ['temperature' => 0.7]);
 
         $this->assertSame('AI response', $answer);

--- a/tests/Infrastructure/Search/OpenAIWebSearchToolTest.php
+++ b/tests/Infrastructure/Search/OpenAIWebSearchToolTest.php
@@ -19,7 +19,7 @@ final class OpenAIWebSearchToolTest extends TestCase
     private MockObject $mockOpenAiClient;
     private MockObject $mockResponsesResource;
     private OpenAIWebSearchTool $webSearchTool;
-    private string $testOpenAiModel = 'gpt-5-mini';
+    private string $testOpenAiModel = 'gpt-5.4-mini';
 
     protected function setUp(): void
     {
@@ -99,7 +99,7 @@ final class OpenAIWebSearchToolTest extends TestCase
         /** @var array{x-request-id: string[], openai-model: string[], openai-organization: string[], openai-version: string[], openai-processing-ms: string[], x-ratelimit-limit-requests: string[], x-ratelimit-remaining-requests: string[], x-ratelimit-reset-requests: string[], x-ratelimit-limit-tokens: string[], x-ratelimit-remaining-tokens: string[], x-ratelimit-reset-tokens: string[]} $headers */
         $headers = [
             'x-request-id' => ['req_123'],
-            'openai-model' => ['gpt-5-mini'],
+            'openai-model' => ['gpt-5.4-mini'],
             'openai-organization' => ['org-123'],
             'openai-version' => ['2020-10-01'],
             'openai-processing-ms' => ['100'],


### PR DESCRIPTION
AIモデルを、コストパフォーマンスに優れた GPT-5.4 Mini に変更しました。
具体的には以下の修正を行いました：
- Containerクラスにて、OpenAiGptClient および OpenAIWebSearchTool に渡すモデル名を 'gpt-5.4-mini' に更新しました。
- README.md の機能説明および技術スタックの項目を新モデル名に合わせて更新しました。
- OpenAiGptClientTest および OpenAIWebSearchToolTest において、モデル名の変更に伴うテストケースの修正を行いました。
- AGENTS.md の「1ファイルについて _template から最新内容を反映すること」という指示に基づき、.vscode/tasks.json を同期しました。
  - phpstan.neon の同期は静的解析レベルの急激な上昇によるエラー多発を避けるため、今回は見送りました。

Fixes #161

---
*PR created automatically by Jules for task [8281746859054929382](https://jules.google.com/task/8281746859054929382) started by @yananob*