### PR TITLE
トリガー実行ロジックのリファクタリング

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,10 +8,7 @@ use Google\CloudFunctions\FunctionsFramework;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use CloudEvents\V1\CloudEventInterface;
-use App\Domain\Bot\Trigger\TimerTrigger;
 use App\Infrastructure\DependencyInjection\Container;
-
-const TIMER_TRIGGERED_BY_N_MINS = 10;
 
 FunctionsFramework::http('main_http', 'main_http');
 function main_http(ServerRequestInterface $request): ResponseInterface
@@ -34,47 +31,9 @@ function main_event(CloudEventInterface $event): void
     $container = new Container();
     $logger = $container->getLogger();
     $logger->logSplitter();
-    $line = $container->getLineClient();
-    $botRepository = $container->getBotRepository();
 
-    foreach ($botRepository->getAllUserBots() as $botUser) {
-        foreach ($botUser->getTriggers() as $trigger) {
-            if (!$trigger instanceof TimerTrigger) {
-                $logger->log("Skipping trigger for user {$botUser->getId()} as it's not a TimerTrigger.");
-                continue;
-            }
-            
-            if ($trigger->getEvent() !== "timer") {
-                continue;
-            }
-
-            if (!$trigger->shouldRunNow(TIMER_TRIGGERED_BY_N_MINS)) {
-                continue;
-            }
-
-            $logger->log(sprintf(
-                "Executing Trigger for bot %s: Date=%s, Time=%s, Request=%s",
-                $botUser->getId(),
-                $trigger->getDate(),
-                $trigger->getTime(),
-                $trigger->getRequest()
-            ));
-
-            try {
-                $chatService = $container->createChatApplicationService($botUser);
-            } catch (\Exception $e) {
-                $logger->log("TRIGGER: Failed to initialize ChatApplicationService for user {$botUser->getId()}: " . $e->getMessage());
-                continue;
-            }
-
-            $answer = $chatService->handleTrigger($trigger)->getText();
-            $line->sendPush(
-                bot: $chatService->getLineTarget(),
-                targetId: $botUser->getId(),
-                message: $answer,
-            );
-        }
-    }
+    $triggerService = $container->createTriggerApplicationService();
+    $triggerService->executeTriggers();
 
     $logger->log("Finished.");
 }

--- a/src/Application/TriggerApplicationService.php
+++ b/src/Application/TriggerApplicationService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application;
+
+use App\Domain\Bot\BotRepository;
+use App\Domain\Bot\Trigger\TimerTrigger;
+use App\Infrastructure\DependencyInjection\Container;
+use App\Infrastructure\Line\LineClient;
+use App\Infrastructure\Logger\Logger;
+
+class TriggerApplicationService
+{
+    private const TIMER_TRIGGERED_BY_N_MINS = 10;
+
+    public function __construct(
+        private BotRepository $botRepository,
+        private LineClient $lineClient,
+        private Container $container,
+        private Logger $logger
+    ) {
+    }
+
+    /**
+     * Executes all eligible triggers for all bots.
+     */
+    public function executeTriggers(): void
+    {
+        foreach ($this->botRepository->getAllUserBots() as $botUser) {
+            foreach ($botUser->getTriggers() as $trigger) {
+                if (!$trigger instanceof TimerTrigger) {
+                    $this->logger->log("Skipping trigger for user {$botUser->getId()} as it's not a TimerTrigger.");
+                    continue;
+                }
+
+                if ($trigger->getEvent() !== "timer") {
+                    continue;
+                }
+
+                if (!$trigger->shouldRunNow(self::TIMER_TRIGGERED_BY_N_MINS)) {
+                    continue;
+                }
+
+                $this->logger->log(sprintf(
+                    "Executing Trigger for bot %s: Date=%s, Time=%s, Request=%s",
+                    $botUser->getId(),
+                    $trigger->getDate(),
+                    $trigger->getTime(),
+                    $trigger->getRequest()
+                ));
+
+                try {
+                    $chatApplicationService = $this->container->createChatApplicationService($botUser);
+                } catch (\Exception $e) {
+                    $this->logger->log("TRIGGER: Failed to initialize ChatApplicationService for user {$botUser->getId()}: " . $e->getMessage());
+                    continue;
+                }
+
+                $answer = $chatApplicationService->handleTrigger($trigger)->getText();
+                $this->lineClient->sendPush(
+                    bot: $chatApplicationService->getLineTarget(),
+                    targetId: $botUser->getId(),
+                    message: $answer,
+                );
+            }
+        }
+    }
+}

--- a/src/Infrastructure/DependencyInjection/Container.php
+++ b/src/Infrastructure/DependencyInjection/Container.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\DependencyInjection;
 
 use App\Application\ChatApplicationService;
+use App\Application\TriggerApplicationService;
 use App\Application\CommandHandler\CommandHandlerDispatcher;
 use App\Application\CommandHandler\CommandHandlerFactory;
 use App\Domain\Bot\Bot;
@@ -136,6 +137,16 @@ class Container
             $this->getConversationRepository(),
             __DIR__ . '/../../../views',
             $cachePath
+        );
+    }
+
+    public function createTriggerApplicationService(): TriggerApplicationService
+    {
+        return new TriggerApplicationService(
+            $this->getBotRepository(),
+            $this->getLineClient(),
+            $this,
+            $this->getLogger()
         );
     }
 

--- a/tests/Application/TriggerApplicationServiceTest.php
+++ b/tests/Application/TriggerApplicationServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Application;
+
+use App\Application\BotResponse;
+use App\Application\ChatApplicationService;
+use App\Application\TriggerApplicationService;
+use App\Domain\Bot\Bot;
+use App\Domain\Bot\BotRepository;
+use App\Domain\Bot\Trigger\TimerTrigger;
+use App\Infrastructure\DependencyInjection\Container;
+use App\Infrastructure\Line\LineClient;
+use App\Infrastructure\Logger\Logger;
+use PHPUnit\Framework\TestCase;
+
+final class TriggerApplicationServiceTest extends TestCase
+{
+    private $botRepositoryMock;
+    private $lineClientMock;
+    private $containerMock;
+    private $loggerMock;
+    private TriggerApplicationService $service;
+
+    protected function setUp(): void
+    {
+        $this->botRepositoryMock = $this->createMock(BotRepository::class);
+        $this->lineClientMock = $this->createMock(LineClient::class);
+        $this->containerMock = $this->createMock(Container::class);
+        $this->loggerMock = $this->createMock(Logger::class);
+
+        $this->service = new TriggerApplicationService(
+            $this->botRepositoryMock,
+            $this->lineClientMock,
+            $this->containerMock,
+            $this->loggerMock
+        );
+    }
+
+    public function test_executeTriggers_processes_eligible_triggers(): void
+    {
+        $bot = $this->createMock(Bot::class);
+        $bot->method('getId')->willReturn('bot_1');
+
+        $trigger = $this->createMock(TimerTrigger::class);
+        $trigger->method('getEvent')->willReturn('timer');
+        $trigger->method('shouldRunNow')->with(10)->willReturn(true);
+        $trigger->method('getDate')->willReturn('2023-10-27');
+        $trigger->method('getTime')->willReturn('10:00');
+        $trigger->method('getRequest')->willReturn('test request');
+
+        $bot->method('getTriggers')->willReturn(['t1' => $trigger]);
+        $this->botRepositoryMock->method('getAllUserBots')->willReturn([$bot]);
+
+        $chatAppServiceMock = $this->createMock(ChatApplicationService::class);
+        $chatAppServiceMock->method('getLineTarget')->willReturn('test_target');
+        $chatAppServiceMock->method('handleTrigger')->with($trigger)->willReturn(new BotResponse('bot response'));
+
+        $this->containerMock->method('createChatApplicationService')->with($bot)->willReturn($chatAppServiceMock);
+
+        $this->lineClientMock->expects($this->once())
+            ->method('sendPush')
+            ->with('test_target', null, 'bot_1', 'bot response');
+
+        $this->service->executeTriggers();
+    }
+
+    public function test_executeTriggers_skips_non_timer_triggers(): void
+    {
+        $bot = $this->createMock(Bot::class);
+        $bot->method('getId')->willReturn('bot_1');
+
+        $nonTimerTrigger = new \stdClass();
+
+        $bot->method('getTriggers')->willReturn(['t1' => $nonTimerTrigger]);
+        $this->botRepositoryMock->method('getAllUserBots')->willReturn([$bot]);
+
+        $this->loggerMock->expects($this->atLeastOnce())
+            ->method('log')
+            ->with($this->stringContains("Skipping trigger for user bot_1 as it's not a TimerTrigger."));
+
+        $this->service->executeTriggers();
+    }
+
+    public function test_executeTriggers_skips_triggers_not_running_now(): void
+    {
+        $bot = $this->createMock(Bot::class);
+        $trigger = $this->createMock(TimerTrigger::class);
+        $trigger->method('getEvent')->willReturn('timer');
+        $trigger->method('shouldRunNow')->willReturn(false);
+
+        $bot->method('getTriggers')->willReturn(['t1' => $trigger]);
+        $this->botRepositoryMock->method('getAllUserBots')->willReturn([$bot]);
+
+        $this->containerMock->expects($this->never())->method('createChatApplicationService');
+        $this->lineClientMock->expects($this->never())->method('sendPush');
+
+        $this->service->executeTriggers();
+        $this->assertTrue(true);
+    }
+
+    public function test_executeTriggers_handles_initialization_failure(): void
+    {
+        $bot = $this->createMock(Bot::class);
+        $bot->method('getId')->willReturn('bot_1');
+        $trigger = $this->createMock(TimerTrigger::class);
+        $trigger->method('getEvent')->willReturn('timer');
+        $trigger->method('shouldRunNow')->willReturn(true);
+
+        $bot->method('getTriggers')->willReturn(['t1' => $trigger]);
+        $this->botRepositoryMock->method('getAllUserBots')->willReturn([$bot]);
+
+        $this->containerMock->method('createChatApplicationService')
+            ->willThrowException(new \Exception('init error'));
+
+        $messages = [];
+        $this->loggerMock->method('log')->willReturnCallback(function ($msg) use (&$messages) {
+            $messages[] = $msg;
+        });
+
+        $this->service->executeTriggers();
+
+        $this->assertContains('Executing Trigger for bot bot_1: Date=, Time=, Request=', $messages);
+        $this->assertStringContainsString('TRIGGER: Failed to initialize ChatApplicationService for user bot_1: init error', implode("\n", $messages));
+    }
+}


### PR DESCRIPTION
index.php（Cloud Functionsのハンドラ）に直接記述されていた「全ボットのトリガーをループして実行する」というビジネスロジックを、新設した `TriggerApplicationService` に抽出しました。これにより、Single Responsibility Principle（単一責任の原則）に則った構成となり、テストの記述も容易になりました。また、依存注入コンテナを通じてサービスを管理するように変更し、テンプレートファイル（phpstan.neon）の同期も行いました。

---
*PR created automatically by Jules for task [9445492885659623932](https://jules.google.com/task/9445492885659623932) started by @yananob*