### PR TITLE
AIモデルを gpt-5.6-luna に変更

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -19,6 +19,8 @@
 .vscode/
 
 *.md
+_template/
+
 # deploy related
 deploy*.sh
 gha-creds-*.json

--- a/src/Infrastructure/DependencyInjection/Container.php
+++ b/src/Infrastructure/DependencyInjection/Container.php
@@ -81,7 +81,7 @@ class Container
         if ($this->gptClient === null) {
             $openaiApiKey = getenv("OPENAI_KEY_LINE_AI_BOT") ?: 'dummy';
             $openaiClient = OpenAI::client($openaiApiKey);
-            $this->gptClient = new OpenAiGptClient($openaiClient, "gpt-5.4-mini", $this->getLogger());
+            $this->gptClient = new OpenAiGptClient($openaiClient, "gpt-5.6-luna", $this->getLogger());
         }
         return $this->gptClient;
     }
@@ -101,7 +101,7 @@ class Container
             if ($openaiApiKey !== 'dummy') {
                 $openaiClient = OpenAI::client($openaiApiKey);
                 try {
-                    $this->webSearchTool = new OpenAIWebSearchTool($openaiClient, "gpt-5.4-mini");
+                    $this->webSearchTool = new OpenAIWebSearchTool($openaiClient, "gpt-5.6-luna");
                 } catch (\Exception $e) {
                     // Log error if needed, but return null as it's optional
                     error_log("Failed to initialize WebSearchTool: " . $e->getMessage());

--- a/tests/Infrastructure/Gpt/OpenAiGptClientTest.php
+++ b/tests/Infrastructure/Gpt/OpenAiGptClientTest.php
@@ -21,7 +21,7 @@ final class OpenAiGptClientTest extends TestCase
         $clientMock->method('chat')->willReturn($chatMock);
 
         $expectedPayload = [
-            'model' => 'gpt-5.4-mini',
+            'model' => 'gpt-5.6-luna',
             'messages' => [
                 ['role' => 'system', 'content' => 'system context'],
                 ['role' => 'user', 'content' => 'user message'],
@@ -36,7 +36,7 @@ final class OpenAiGptClientTest extends TestCase
             'id' => 'chatcmpl-123',
             'object' => 'chat.completion',
             'created' => 1677652288,
-            'model' => 'gpt-5.4-mini',
+            'model' => 'gpt-5.6-luna',
             'choices' => [
                 [
                     'index' => 0,
@@ -59,7 +59,7 @@ final class OpenAiGptClientTest extends TestCase
         /** @var array{x-request-id: string[], openai-model: string[], openai-organization: string[], openai-version: string[], openai-processing-ms: string[], x-ratelimit-limit-requests: string[], x-ratelimit-remaining-requests: string[], x-ratelimit-reset-requests: string[], x-ratelimit-limit-tokens: string[], x-ratelimit-remaining-tokens: string[], x-ratelimit-reset-tokens: string[]} $headers */
         $headers = [
             'x-request-id' => ['req_123'],
-            'openai-model' => ['gpt-5.4-mini'],
+            'openai-model' => ['gpt-5.6-luna'],
             'openai-organization' => ['org-123'],
             'openai-version' => ['2020-10-01'],
             'openai-processing-ms' => ['100'],
@@ -78,7 +78,7 @@ final class OpenAiGptClientTest extends TestCase
             ->with($expectedPayload)
             ->willReturn($response);
 
-        $gptClient = new OpenAiGptClient($clientMock, 'gpt-5.4-mini');
+        $gptClient = new OpenAiGptClient($clientMock, 'gpt-5.6-luna');
         $answer = $gptClient->getAnswer('system context', 'user message', ['temperature' => 0.7]);
 
         $this->assertSame('AI response', $answer);

--- a/tests/Infrastructure/Search/OpenAIWebSearchToolTest.php
+++ b/tests/Infrastructure/Search/OpenAIWebSearchToolTest.php
@@ -19,7 +19,7 @@ final class OpenAIWebSearchToolTest extends TestCase
     private MockObject $mockOpenAiClient;
     private MockObject $mockResponsesResource;
     private OpenAIWebSearchTool $webSearchTool;
-    private string $testOpenAiModel = 'gpt-5.4-mini';
+    private string $testOpenAiModel = 'gpt-5.6-luna';
 
     protected function setUp(): void
     {
@@ -99,7 +99,7 @@ final class OpenAIWebSearchToolTest extends TestCase
         /** @var array{x-request-id: string[], openai-model: string[], openai-organization: string[], openai-version: string[], openai-processing-ms: string[], x-ratelimit-limit-requests: string[], x-ratelimit-remaining-requests: string[], x-ratelimit-reset-requests: string[], x-ratelimit-limit-tokens: string[], x-ratelimit-remaining-tokens: string[], x-ratelimit-reset-tokens: string[]} $headers */
         $headers = [
             'x-request-id' => ['req_123'],
-            'openai-model' => ['gpt-5.4-mini'],
+            'openai-model' => ['gpt-5.6-luna'],
             'openai-organization' => ['org-123'],
             'openai-version' => ['2020-10-01'],
             'openai-processing-ms' => ['100'],


### PR DESCRIPTION
使用するAIモデルを gpt-5.4-mini から gpt-5.6-luna に変更し、関連するテストケースおよび依存関係を更新しました。さらに、_template から .gcloudignore ファイルを同期しました。

---
*PR created automatically by Jules for task [3299314377999599945](https://jules.google.com/task/3299314377999599945) started by @yananob*