### PR TITLE
バックエンドのリファクタリング（DDDの強化とWeb検索ロジックの分離）

### DIFF
--- a/src/Application/Config/ConfigApplicationService.php
+++ b/src/Application/Config/ConfigApplicationService.php
@@ -5,6 +5,8 @@ namespace App\Application\Config;
 use App\Domain\Bot\BotRepository;
 use App\Domain\Bot\Trigger\TimerTrigger;
 use App\Domain\Conversation\ConversationRepository;
+use App\Domain\Bot\ValueObject\BotPersonalityConfig;
+use App\Domain\Bot\ValueObject\StringList;
 use eftec\bladeone\BladeOne;
 
 class ConfigApplicationService
@@ -70,7 +72,7 @@ class ConfigApplicationService
                 $botName = $bot->getName();
                 $botChars = $bot->getPersonality()->getBotCharacteristics()->toArray();
                 $humanChars = $bot->getPersonality()->getHumanCharacteristics()->toArray();
-                $requests = $bot->getConfigRequests(true, false)->toArray();
+                $requests = $bot->getPersonality()->getConfigRequests()->toArray();
                 $lineTarget = $bot->getLineTarget();
             } catch (\Exception $e) {
                 // Bot not found, use defaults
@@ -169,11 +171,11 @@ class ConfigApplicationService
     {
         $bot = $this->botRepository->findOrDefault($botId);
         $bot->setName($data['bot_name'] ?? '');
-        $bot->setPersonality(new \App\Domain\Bot\ValueObject\BotPersonalityConfig(
-            new \App\Domain\Bot\ValueObject\StringList($data['bot_characteristics'] ?? []),
-            new \App\Domain\Bot\ValueObject\StringList($data['human_characteristics'] ?? [])
+        $bot->setPersonality(new BotPersonalityConfig(
+            new StringList($data['bot_characteristics'] ?? []),
+            new StringList($data['human_characteristics'] ?? []),
+            new StringList($data['requests'] ?? [])
         ));
-        $bot->setConfigRequests(new \App\Domain\Bot\ValueObject\StringList($data['requests'] ?? []));
         $bot->setLineTarget($data['line_target'] ?? '');
         $this->botRepository->save($bot);
     }

--- a/src/Domain/Bot/Bot.php
+++ b/src/Domain/Bot/Bot.php
@@ -12,7 +12,6 @@ class Bot
     private string $id;
     private string $name;
     private BotPersonalityConfig $personality;
-    private StringList $configRequests;
     private string $lineTarget;
     private array $triggers; // This will hold Trigger objects
     private ?Bot $defaultBot;
@@ -21,7 +20,6 @@ class Bot
      * @param string $id
      * @param string $name
      * @param BotPersonalityConfig|null $personality
-     * @param StringList|null $configRequests
      * @param string $lineTarget
      * @param array<string, Trigger> $triggers
      * @param Bot|null $defaultBot
@@ -30,7 +28,6 @@ class Bot
         string $id,
         string $name = '',
         ?BotPersonalityConfig $personality = null,
-        ?StringList $configRequests = null,
         string $lineTarget = '',
         array $triggers = [],
         ?Bot $defaultBot = null
@@ -38,7 +35,6 @@ class Bot
         $this->id = $id;
         $this->name = $name;
         $this->personality = $personality ?? new BotPersonalityConfig(new StringList([]), new StringList([]));
-        $this->configRequests = $configRequests ?? new StringList([]);
         $this->lineTarget = $lineTarget;
         $this->triggers = $triggers;
         $this->defaultBot = $defaultBot;
@@ -64,47 +60,44 @@ class Bot
         return $this->personality;
     }
 
+    public function getMergedPersonality(): BotPersonalityConfig
+    {
+        if ($this->defaultBot !== null) {
+            return $this->personality->merge($this->defaultBot->getPersonality());
+        }
+        return $this->personality;
+    }
+
     public function getBotCharacteristics(): StringList
     {
-        $chars = $this->personality->getBotCharacteristics();
-        if ($this->defaultBot !== null) {
-            $defaultChars = $this->defaultBot->getBotCharacteristics();
-            $chars = $defaultChars->merge($chars);
-        }
-        return $chars;
+        return $this->getMergedPersonality()->getBotCharacteristics();
     }
 
     public function getHumanCharacteristics(): StringList
     {
-        $chars = $this->personality->getHumanCharacteristics();
-        if ($this->defaultBot !== null) {
-            $defaultChars = $this->defaultBot->getHumanCharacteristics();
-            $chars = $defaultChars->merge($chars);
-        }
-        return $chars;
+        return $this->getMergedPersonality()->getHumanCharacteristics();
     }
 
     public function hasHumanCharacteristics(): bool
     {
-        if (!$this->personality->getHumanCharacteristics()->isEmpty()) {
-            return true;
-        }
-        return $this->defaultBot !== null && $this->defaultBot->hasHumanCharacteristics();
+        return !$this->getHumanCharacteristics()->isEmpty();
     }
 
     public function getConfigRequests(bool $usePersonal = true, bool $useDefault = true): StringList
     {
-        $requests = new StringList([]);
+        if ($usePersonal && $useDefault) {
+            return $this->getMergedPersonality()->getConfigRequests();
+        }
+
         if ($usePersonal) {
-            $requests = $this->configRequests;
+            return $this->personality->getConfigRequests();
         }
 
         if ($useDefault && $this->defaultBot !== null) {
-            $defaultRequests = $this->defaultBot->getConfigRequests(true, false);
-            // Default requests come first
-            $requests = $defaultRequests->merge($requests);
+            return $this->defaultBot->getPersonality()->getConfigRequests();
         }
-        return $requests;
+
+        return new StringList([]);
     }
 
     public function getLineTarget(): string
@@ -148,7 +141,12 @@ class Bot
 
     public function setConfigRequests(StringList $configRequests): void
     {
-        $this->configRequests = $configRequests;
+        // For compatibility with previous API, update personality's configRequests
+        $this->personality = new BotPersonalityConfig(
+            $this->personality->getBotCharacteristics(),
+            $this->personality->getHumanCharacteristics(),
+            $configRequests
+        );
     }
 
     public function setLineTarget(string $target): void

--- a/src/Domain/Bot/Service/BotFactory.php
+++ b/src/Domain/Bot/Service/BotFactory.php
@@ -24,15 +24,14 @@ class BotFactory
     ): Bot {
         $personality = new BotPersonalityConfig(
             new StringList($data['bot_characteristics'] ?? []),
-            new StringList($data['human_characteristics'] ?? [])
+            new StringList($data['human_characteristics'] ?? []),
+            new StringList($data['requests'] ?? [])
         );
-        $configRequests = new StringList($data['requests'] ?? []);
 
         return new Bot(
             $id,
             $data['bot_name'] ?? '',
             $personality,
-            $configRequests,
             $data['line_target'] ?? '',
             $triggers,
             $defaultBot

--- a/src/Domain/Bot/Service/ChatService.php
+++ b/src/Domain/Bot/Service/ChatService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Domain\Bot\Service;
 
 use App\Domain\Bot\Bot;
-use App\Domain\Bot\Messages;
 use App\Domain\Conversation\ConversationRepository;
 use App\Domain\Bot\ValueObject\Message;
 
@@ -14,7 +13,7 @@ class ChatService
     private GptInterface $gpt;
     private ConversationRepository $conversationRepository;
     private ChatPromptService $chatPromptService;
-    private ?WebSearchInterface $webSearchTool;
+    private WebSearchDomainService $webSearchDomainService;
 
     const RECENT_CONVERSATIONS_COUNT_FOR_GPT = 10;
 
@@ -22,12 +21,12 @@ class ChatService
         GptInterface $gpt,
         ConversationRepository $conversationRepository,
         ChatPromptService $chatPromptService,
-        ?WebSearchInterface $webSearchTool = null
+        WebSearchDomainService $webSearchDomainService
     ) {
         $this->gpt = $gpt;
         $this->conversationRepository = $conversationRepository;
         $this->chatPromptService = $chatPromptService;
-        $this->webSearchTool = $webSearchTool;
+        $this->webSearchDomainService = $webSearchDomainService;
     }
 
     public function generateAnswer(Bot $bot, Message $message): string
@@ -37,14 +36,7 @@ class ChatService
             self::RECENT_CONVERSATIONS_COUNT_FOR_GPT
         );
 
-        $webSearchResults = null;
-        if ($this->shouldPerformWebSearch($message->getContent())) {
-            if ($this->webSearchTool instanceof WebSearchInterface) {
-                $webSearchResults = $this->webSearchTool->search($message->getContent(), 5);
-            } else {
-                $webSearchResults = "Error: Web search tool is not configured properly or failed to initialize.";
-            }
-        }
+        $webSearchResults = $this->webSearchDomainService->performWebSearchIfNeeded($message->getContent());
 
         $configRequests = $bot->getConfigRequests(usePersonal: true, useDefault: true);
 
@@ -57,14 +49,5 @@ class ChatService
             ),
             message: $message->getContent(),
         );
-    }
-
-    private function shouldPerformWebSearch(string $messageContent): bool
-    {
-        $response = trim($this->gpt->getAnswer(
-            context: Messages::PROMPT_JUDGE_WEB_SEARCH,
-            message: $messageContent,
-        ));
-        return $response === "はい";
     }
 }

--- a/src/Domain/Bot/Service/WebSearchDomainService.php
+++ b/src/Domain/Bot/Service/WebSearchDomainService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Bot\Service;
+
+use App\Domain\Bot\Messages;
+
+class WebSearchDomainService
+{
+    private GptInterface $gpt;
+    private ?WebSearchInterface $webSearchTool;
+
+    public function __construct(GptInterface $gpt, ?WebSearchInterface $webSearchTool = null)
+    {
+        $this->gpt = $gpt;
+        $this->webSearchTool = $webSearchTool;
+    }
+
+    public function performWebSearchIfNeeded(string $messageContent): ?string
+    {
+        if (!$this->shouldPerformWebSearch($messageContent)) {
+            return null;
+        }
+
+        if ($this->webSearchTool instanceof WebSearchInterface) {
+            return $this->webSearchTool->search($messageContent, 5);
+        }
+
+        return "Error: Web search tool is not configured properly or failed to initialize.";
+    }
+
+    private function shouldPerformWebSearch(string $messageContent): bool
+    {
+        $response = trim($this->gpt->getAnswer(
+            context: Messages::PROMPT_JUDGE_WEB_SEARCH,
+            message: $messageContent,
+        ));
+        return $response === "はい";
+    }
+}

--- a/src/Domain/Bot/ValueObject/BotPersonalityConfig.php
+++ b/src/Domain/Bot/ValueObject/BotPersonalityConfig.php
@@ -6,7 +6,8 @@ class BotPersonalityConfig
 {
     public function __construct(
         private StringList $botCharacteristics,
-        private StringList $humanCharacteristics
+        private StringList $humanCharacteristics,
+        private StringList $configRequests = new StringList([])
     ) {
     }
 
@@ -20,8 +21,24 @@ class BotPersonalityConfig
         return $this->humanCharacteristics;
     }
 
+    public function getConfigRequests(): StringList
+    {
+        return $this->configRequests;
+    }
+
     public function isEmpty(): bool
     {
-        return $this->botCharacteristics->isEmpty() && $this->humanCharacteristics->isEmpty();
+        return $this->botCharacteristics->isEmpty() &&
+               $this->humanCharacteristics->isEmpty() &&
+               $this->configRequests->isEmpty();
+    }
+
+    public function merge(BotPersonalityConfig $default): self
+    {
+        return new self(
+            $default->getBotCharacteristics()->merge($this->botCharacteristics),
+            $default->getHumanCharacteristics()->merge($this->humanCharacteristics),
+            $default->getConfigRequests()->merge($this->configRequests)
+        );
     }
 }

--- a/src/Infrastructure/DependencyInjection/Container.php
+++ b/src/Infrastructure/DependencyInjection/Container.php
@@ -11,6 +11,7 @@ use App\Application\CommandHandler\CommandHandlerFactory;
 use App\Domain\Bot\Bot;
 use App\Domain\Bot\Service\ChatPromptService;
 use App\Domain\Bot\Service\ChatService;
+use App\Domain\Bot\Service\WebSearchDomainService;
 use App\Domain\Bot\Service\CommandAndTriggerService;
 use App\Infrastructure\Gpt\OpenAiGptClient;
 use App\Infrastructure\Logger\Logger;
@@ -29,6 +30,7 @@ class Container
     private ?FirestoreConversationRepository $conversationRepository = null;
     private ?ChatPromptService $chatPromptService = null;
     private ?ChatService $chatService = null;
+    private ?WebSearchDomainService $webSearchDomainService = null;
     private ?OpenAiGptClient $gptClient = null;
     private ?CommandAndTriggerService $commandAndTriggerService = null;
     private ?OpenAIWebSearchTool $webSearchTool = null;
@@ -70,10 +72,21 @@ class Container
                 $this->getGptClient(),
                 $this->getConversationRepository(),
                 $this->getChatPromptService(),
-                $this->getWebSearchTool()
+                $this->getWebSearchDomainService()
             );
         }
         return $this->chatService;
+    }
+
+    public function getWebSearchDomainService(): WebSearchDomainService
+    {
+        if ($this->webSearchDomainService === null) {
+            $this->webSearchDomainService = new WebSearchDomainService(
+                $this->getGptClient(),
+                $this->getWebSearchTool()
+            );
+        }
+        return $this->webSearchDomainService;
     }
 
     public function getGptClient(): OpenAiGptClient

--- a/tests/Domain/Bot/BotTest.php
+++ b/tests/Domain/Bot/BotTest.php
@@ -43,7 +43,7 @@ final class BotTest extends TestCase
     {
         $defaultPersonality = new BotPersonalityConfig(new StringList(['デフォルト特性']), new StringList([]));
         $defaultBot = new Bot("defaultBotId", "Default", $defaultPersonality);
-        $botWithDefault = new Bot("botWithDef", "MyBot", null, null, '', [], $defaultBot);
+        $botWithDefault = new Bot("botWithDef", "MyBot", null, '', [], $defaultBot);
         $this->assertEquals(['デフォルト特性'], $botWithDefault->getBotCharacteristics()->toArray());
 
         // 個別設定がある場合はマージされる
@@ -72,7 +72,7 @@ final class BotTest extends TestCase
     {
         $defaultPersonality = new BotPersonalityConfig(new StringList([]), new StringList(['デフォルト人間特性']));
         $defaultBot = new Bot("defaultBotId", "Default", $defaultPersonality);
-        $botWithDefault = new Bot("botWithDef", "MyBot", null, null, '', [], $defaultBot);
+        $botWithDefault = new Bot("botWithDef", "MyBot", null, '', [], $defaultBot);
 
         $this->assertTrue($botWithDefault->hasHumanCharacteristics());
     }
@@ -81,7 +81,7 @@ final class BotTest extends TestCase
     {
         $defaultPersonality = new BotPersonalityConfig(new StringList([]), new StringList(['デフォルト人間特性']));
         $defaultBot = new Bot("defaultBotId", "Default", $defaultPersonality);
-        $botWithDefault = new Bot("botWithDef", "MyBot", null, null, '', [], $defaultBot);
+        $botWithDefault = new Bot("botWithDef", "MyBot", null, '', [], $defaultBot);
 
         $this->assertTrue($botWithDefault->hasHumanCharacteristics());
         $this->assertEquals(['デフォルト人間特性'], $botWithDefault->getHumanCharacteristics()->toArray());
@@ -96,15 +96,18 @@ final class BotTest extends TestCase
     public function test_設定リクエストを取得する(): void
     {
         $reqs = ["リクエストA", "リクエストB"];
-        $bot = new Bot("testBotId", "TestBot", null, new StringList($reqs));
+        $personality = new BotPersonalityConfig(new StringList([]), new StringList([]), new StringList($reqs));
+        $bot = new Bot("testBotId", "TestBot", $personality);
         $this->assertEquals($reqs, $bot->getConfigRequests(true, false)->toArray());
     }
 
     public function test_設定リクエストがデフォルトとマージされることを確認する(): void
     {
-        $defaultBot = new Bot("defaultBotId", "Default", null, new StringList(['デフォルトリクエスト']));
+        $defaultPersonality = new BotPersonalityConfig(new StringList([]), new StringList([]), new StringList(['デフォルトリクエスト']));
+        $defaultBot = new Bot("defaultBotId", "Default", $defaultPersonality);
 
-        $bot = new Bot("myBot", "MyBot", null, new StringList(['個別リクエスト']), '', [], $defaultBot);
+        $personality = new BotPersonalityConfig(new StringList([]), new StringList([]), new StringList(['個別リクエスト']));
+        $bot = new Bot("myBot", "MyBot", $personality, '', [], $defaultBot);
 
         $allRequests = $bot->getConfigRequests(true, true);
         $this->assertEquals(['デフォルトリクエスト', '個別リクエスト'], $allRequests->toArray());
@@ -127,9 +130,9 @@ final class BotTest extends TestCase
 
     public function test_LINEターゲットが設定されていない場合にデフォルトから取得する(): void
     {
-        $defaultBot = new Bot("defaultBotId", "Default", null, null, "default_target");
+        $defaultBot = new Bot("defaultBotId", "Default", null, "default_target");
 
-        $bot = new Bot("myBot", "MyBot", null, null, '', [], $defaultBot);
+        $bot = new Bot("myBot", "MyBot", null, '', [], $defaultBot);
         $this->assertEquals("default_target", $bot->getLineTarget());
 
         $bot->setLineTarget("personal_target");

--- a/tests/Domain/Bot/Service/ChatServiceTest.php
+++ b/tests/Domain/Bot/Service/ChatServiceTest.php
@@ -12,6 +12,7 @@ use App\Domain\Bot\Service\WebSearchInterface;
 use App\Domain\Bot\Service\GptInterface;
 use App\Domain\Bot\ValueObject\Message;
 use App\Domain\Bot\Service\ChatService;
+use App\Domain\Bot\Service\WebSearchDomainService;
 use PHPUnit\Framework\TestCase;
 
 final class ChatServiceTest extends TestCase
@@ -28,11 +29,12 @@ final class ChatServiceTest extends TestCase
         $this->convRepoMock = $this->createMock(ConversationRepository::class);
         $this->promptService = new ChatPromptService();
         $this->webSearchMock = $this->createMock(WebSearchInterface::class);
+        $webSearchDomainService = new WebSearchDomainService($this->gptMock, $this->webSearchMock);
         $this->chatService = new ChatService(
             $this->gptMock,
             $this->convRepoMock,
             $this->promptService,
-            $this->webSearchMock
+            $webSearchDomainService
         );
     }
 
@@ -89,7 +91,8 @@ final class ChatServiceTest extends TestCase
 
     public function test_generateAnswer_withWebSearchToolNull_containsErrorMessageInContext(): void
     {
-        $chatService = new ChatService($this->gptMock, $this->convRepoMock, $this->promptService, null);
+        $webSearchDomainService = new WebSearchDomainService($this->gptMock, null);
+        $chatService = new ChatService($this->gptMock, $this->convRepoMock, $this->promptService, $webSearchDomainService);
         $bot = new Bot("test");
 
         $this->gptMock->method('getAnswer')->willReturnCallback(function($context, $message) {

--- a/tests/Infrastructure/Persistence/Firestore/FirestoreBotRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/Firestore/FirestoreBotRepositoryTest.php
@@ -263,7 +263,7 @@ final class FirestoreBotRepositoryTest extends TestCase
         $defaultBot = new Bot('default', 'Default', $defaultPersonality);
 
         $personality = new BotPersonalityConfig(new StringList(['personal-char']), new StringList([]));
-        $bot = new Bot('test-bot', 'Personal Name', $personality, null, '', [], $defaultBot);
+        $bot = new Bot('test-bot', 'Personal Name', $personality, '', [], $defaultBot);
 
         [$botCollMock, $configDocMock] = $this->createBotMocks();
 


### PR DESCRIPTION
保守性を高めるため、以下のリファクタリングを実施しました。

1. **BotPersonalityConfig値オブジェクトの導入と強化**:
   - `botCharacteristics`, `humanCharacteristics`, `configRequests` を `BotPersonalityConfig` に集約しました。
   - デフォルト設定とのマージロジックを `BotPersonalityConfig::merge()` にカプセル化し、`Bot` アグリゲート内の重複を排除しました。

2. **WebSearchDomainServiceの抽出**:
   - `ChatService` に混在していたWeb検索の必要性判定と実行ロジックを `WebSearchDomainService` に抽出しました。これにより、各サービスの責務が明確になり、テストが容易になりました。

3. **テストコードの更新**:
   - リファクタリングに伴う構造変更に合わせて、既存のユニットテストをすべて修正・更新しました。

4. **テンプレート同期**:
   - `_template/phpstan.neon` をプロジェクトルートに反映しました。

すべてのテスト (`phpunit`) と静的解析 (`phpstan`) がパスすることを確認済みです。

---
*PR created automatically by Jules for task [914611559675574985](https://jules.google.com/task/914611559675574985) started by @yananob*