### PR TITLE
ドメインイベント配信（DomainEventPublisher）の導入とリポジトリ層リファクタリング

### DIFF
--- a/docs/implementation_policy.md
+++ b/docs/implementation_policy.md
@@ -1,0 +1,79 @@
+# 実装方針ガイドライン
+
+このドキュメントは、本プロジェクト（Cloud Functions + Firestore + PHP）の設計思想、環境変数の運用、および主要な実装パターンをまとめたものです。新しい機能の追加や、同様の構成で新しいプロジェクトを開始する際の指針として利用してください。
+
+---
+
+## 1. アーキテクチャ概要
+
+本アプリケーションは、Google Cloud Functions を基盤としたサーバーレスアーキテクチャを採用しています。
+
+- **ランタイム**: PHP 8.2 以上
+- **データベース**: Google Cloud Firestore (Native Mode)
+- **ビュー**: BladeOne を使用してテンプレートを描画します。
+- **エントリポイント (`index.php`)**:
+  - `main_http`: HTTPリクエストを処理します。
+  - `main_event`: Pub/Sub などのイベントを処理します。
+
+---
+
+## 2. 環境変数の管理
+
+環境変数は、アプリケーションの挙動を環境（開発・テスト・本番）ごとに切り替えるために重要です。
+
+### 主要な環境変数
+
+| 変数名 | 説明 | 備考 |
+| :--- | :--- | :--- |
+| `APP_ENV` | 実行環境の指定。`production`, `test`, `development` のいずれか。 | デフォルト値はなしにする（設定の問題が分かりやすくなるよう）|
+| `FIREBASE_SERVICE_ACCOUNT` | Firestore 操作用のサービスアカウントキー（JSON形式）。 | サーバーサイドでの認証に使用 |
+| `OPENAI_KEY_XXXX` | OpenAI API のシークレットキー。 | `XXXX` はアプリごとに変える |
+| `K_SERVICE` | Cloud Functions のサービス名。 | URLの組み立てなどに使用 |
+
+### 環境変数の取得方法
+
+原則として直接 `getenv()` を呼び出すのではなく、`src/AppConfig.php` 等を介して取得します。これにより、デフォルト値の設定や環境ごとのロジック変更を抽象化します。
+
+---
+
+## 3. Firestore の初期化
+
+Firestore へのアクセスには、環境変数 `FIREBASE_SERVICE_ACCOUNT` に設定された JSON キーを使用します。
+
+### ライブラリの初期化例
+
+Google Cloud PHP クライアントライブラリを使用する場合、JSON キーの内容を直接渡して初期化します。
+
+```php
+$config = json_decode(getenv("FIREBASE_SERVICE_ACCOUNT"), true);
+$firestore = new FirestoreClient([
+    "keyFile" => $config
+]);
+```
+
+---
+
+## 4. コーディング規約とルール
+
+- **日付操作**: 必ず `Carbon\Carbon` を使用してください。
+- **命名規則**:
+  - PHP/JavaScript の変数・メソッド名は `camelCase`。
+  - クラス名は `PascalCase`。
+- **CSS**: Tailwind CSS をデフォルトとして使用してください。
+- **環境の識別**:
+  - テスト環境では、本番環境と区別しやすくするため、画面上部に現在のベースパスとリクエストパスをオーバーレイで表示します。
+- **デプロイとシークレット**:
+  デプロイは GitHub Actions (`.github/workflows/deploy-*.yaml`) で自動化します。機密性の高い環境変数（`FIREBASE_SERVICE_ACCOUNT` 等）は、GitHub Secrets に保存され、デプロイ時に Cloud Functions の環境変数として設定されます。
+- 処理状況が分かるように、適宜ログを出力する。ログ出力には monolog を使う。
+
+---
+
+## 5. テストコードの方針
+
+テストコードを記載する際は、以下の指針に従ってください。
+
+- **古典派（Classical School）の考え方**:
+  - モックの使用は最小限にとどめます。
+  - ユニットテストにおいても、依存先を含めた実際のクラスの組み合わせでテストすることを優先します。
+- **振る舞いのテスト**:
+  - 内部の実装詳細ではなく、外部から見た振る舞い（Behavior）をテストできるようにします。

--- a/src/Domain/Bot/Event/DomainEventPublisher.php
+++ b/src/Domain/Bot/Event/DomainEventPublisher.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace App\Domain\Bot\Event;
+
+/**
+ * ドメインイベントの登録と配信を管理するパブリッシャー（シングルトン）。
+ */
+class DomainEventPublisher
+{
+    private static ?self $instance = null;
+
+    /**
+     * イベント購読者のリスト
+     * @var array<string, array<callable>>
+     */
+    private array $subscribers = [];
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * シングルトンインスタンスを取得します。
+     */
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * シングルトンインスタンスを明示的に設定またはクリアします（テスト用）。
+     */
+    public static function setInstance(?self $instance): void
+    {
+        self::$instance = $instance;
+    }
+
+    /**
+     * 特定のイベントクラス、またはすべてのイベント（"*"）に対するサブスクライバーを登録します。
+     *
+     * @param string $eventClass イベントクラスの完全修飾名、または '*'
+     * @param callable $subscriber function(DomainEvent $event): void 形式のコールバック
+     */
+    public function subscribe(string $eventClass, callable $subscriber): void
+    {
+        $this->subscribers[$eventClass][] = $subscriber;
+    }
+
+    /**
+     * イベントをパブリッシュし、登録されているすべての購読者に通知します。
+     */
+    public function publish(DomainEvent $event): void
+    {
+        $eventClass = get_class($event);
+
+        // 1. 特定のイベントに対する購読者の通知
+        if (isset($this->subscribers[$eventClass])) {
+            foreach ($this->subscribers[$eventClass] as $subscriber) {
+                $subscriber($event);
+            }
+        }
+
+        // 2. すべてのイベント（ワイルドカード）に対する購読者の通知
+        if (isset($this->subscribers['*'])) {
+            foreach ($this->subscribers['*'] as $subscriber) {
+                $subscriber($event);
+            }
+        }
+    }
+
+    /**
+     * 登録されているすべてのサブスクライバーをクリアします（テスト用）。
+     */
+    public function clear(): void
+    {
+        $this->subscribers = [];
+    }
+}

--- a/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
+++ b/src/Infrastructure/Persistence/Firestore/FirestoreBotRepository.php
@@ -12,6 +12,7 @@ use App\Domain\Bot\Service\BotFactory;
 use App\Domain\Bot\Trigger\TriggerFactory;
 use App\Domain\Exception\BotNotFoundException;
 use App\Domain\Bot\Event\BotCreatedEvent;
+use App\Domain\Bot\Event\DomainEventPublisher;
 
 class FirestoreBotRepository extends AbstractFirestoreRepository implements BotRepository
 {
@@ -131,6 +132,11 @@ class FirestoreBotRepository extends AbstractFirestoreRepository implements BotR
         foreach ($bot->getTriggers() as $trigger) {
             $triggerId = $trigger->getId() ?: uniqid('trigger_');
             $triggersCollection->document($triggerId)->set($trigger->toArray());
+        }
+
+        // ドメインイベントの発行
+        foreach ($bot->releaseEvents() as $event) {
+            DomainEventPublisher::getInstance()->publish($event);
         }
     }
 

--- a/src/Infrastructure/Persistence/Firestore/FirestoreConversationRepository.php
+++ b/src/Infrastructure/Persistence/Firestore/FirestoreConversationRepository.php
@@ -9,6 +9,7 @@ use Google\Cloud\Firestore\Query;
 use App\Domain\Conversation\Conversation;
 use App\Domain\Conversation\ConversationRepository;
 use App\Domain\Conversation\ValueObject\Speaker;
+use App\Domain\Bot\Event\DomainEventPublisher;
 use DateTimeImmutable;
 use DateTimeZone;
 
@@ -94,6 +95,11 @@ class FirestoreConversationRepository extends AbstractFirestoreRepository implem
             // Add new conversation, Firestore will generate an ID
             $docRef = $conversationsCollection->add($data);
             $conversation->setId($docRef->id()); // Set the ID back to the entity object
+        }
+
+        // ドメインイベントの発行
+        foreach ($conversation->releaseEvents() as $event) {
+            DomainEventPublisher::getInstance()->publish($event);
         }
     }
 

--- a/tests/Domain/Bot/Event/DomainEventPublisherTest.php
+++ b/tests/Domain/Bot/Event/DomainEventPublisherTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Domain\Bot\Event;
+
+use PHPUnit\Framework\TestCase;
+use App\Domain\Bot\Event\DomainEventPublisher;
+use App\Domain\Bot\Event\BotCreatedEvent;
+use App\Domain\Bot\Event\BotConfigChangedEvent;
+use App\Domain\Bot\ValueObject\BotPersonalityConfig;
+use App\Domain\Bot\ValueObject\StringList;
+
+class DomainEventPublisherTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DomainEventPublisher::getInstance()->clear();
+    }
+
+    protected function tearDown(): void
+    {
+        DomainEventPublisher::getInstance()->clear();
+        parent::tearDown();
+    }
+
+    public function test_subscribe_and_publish_specific_event(): void
+    {
+        $publisher = DomainEventPublisher::getInstance();
+
+        $receivedEvent = null;
+        $publisher->subscribe(BotCreatedEvent::class, function ($event) use (&$receivedEvent) {
+            $receivedEvent = $event;
+        });
+
+        $event = new BotCreatedEvent("bot-123", "Test Bot");
+        $publisher->publish($event);
+
+        $this->assertSame($event, $receivedEvent);
+    }
+
+    public function test_subscribe_all_events_using_wildcard(): void
+    {
+        $publisher = DomainEventPublisher::getInstance();
+
+        $receivedEvents = [];
+        $publisher->subscribe('*', function ($event) use (&$receivedEvents) {
+            $receivedEvents[] = $event;
+        });
+
+        $event1 = new BotCreatedEvent("bot-123", "Test Bot");
+        $event2 = new BotConfigChangedEvent("bot-123", "Test Bot 2", new BotPersonalityConfig(new StringList([]), new StringList([])));
+
+        $publisher->publish($event1);
+        $publisher->publish($event2);
+
+        $this->assertCount(2, $receivedEvents);
+        $this->assertSame($event1, $receivedEvents[0]);
+        $this->assertSame($event2, $receivedEvents[1]);
+    }
+}

--- a/tests/Infrastructure/Persistence/Firestore/FirestoreBotRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/Firestore/FirestoreBotRepositoryTest.php
@@ -342,4 +342,28 @@ final class FirestoreBotRepositoryTest extends TestCase
 
         $this->repository->delete($botId);
     }
+
+    public function test_save_publishes_domain_events(): void
+    {
+        $bot = new Bot('test-bot', 'Initial Name');
+        $bot->setName('New Name'); // Records BotConfigChangedEvent
+
+        // Let's mock firestore save behavior
+        [$botCollMock, $configDocMock] = $this->createBotMocks();
+        $this->documentRootMock->method('collection')->with('test-bot')->willReturn($botCollMock);
+
+        $publisher = \App\Domain\Bot\Event\DomainEventPublisher::getInstance();
+        $publisher->clear();
+
+        $dispatchedEvents = [];
+        $publisher->subscribe(\App\Domain\Bot\Event\BotConfigChangedEvent::class, function($event) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $event;
+        });
+
+        $this->repository->save($bot);
+
+        $this->assertCount(1, $dispatchedEvents);
+        $this->assertSame('test-bot', $dispatchedEvents[0]->getBotId());
+        $this->assertSame('New Name', $dispatchedEvents[0]->getName());
+    }
 }

--- a/tests/Infrastructure/Persistence/Firestore/FirestoreConversationRepositoryTest.php
+++ b/tests/Infrastructure/Persistence/Firestore/FirestoreConversationRepositoryTest.php
@@ -208,4 +208,31 @@ final class FirestoreConversationRepositoryTest extends TestCase // TestCaseの�
 
         $this->repository->findByBotId($botId, $limit, $offset);
     }
+
+    public function test_save_publishes_conversation_stored_event(): void
+    {
+        $conversation = new Conversation("testBotId", Speaker::HUMAN, "メッセージ");
+
+        $newDocRefMock = $this->createMock(DocumentReference::class);
+        $newDocRefMock->method('id')->willReturn('new-doc-id');
+
+        $this->botConversationsCollRefMock->expects($this->once())
+            ->method('add')
+            ->willReturn($newDocRefMock);
+
+        $publisher = \App\Domain\Bot\Event\DomainEventPublisher::getInstance();
+        $publisher->clear();
+
+        $dispatchedEvents = [];
+        $publisher->subscribe(\App\Domain\Conversation\Event\ConversationStoredEvent::class, function($event) use (&$dispatchedEvents) {
+            $dispatchedEvents[] = $event;
+        });
+
+        $this->repository->save($conversation);
+
+        $this->assertCount(1, $dispatchedEvents);
+        $this->assertSame('testBotId', $dispatchedEvents[0]->getBotId());
+        $this->assertSame(Speaker::HUMAN, $dispatchedEvents[0]->getSpeaker());
+        $this->assertSame('メッセージ', $dispatchedEvents[0]->getContent());
+    }
 }


### PR DESCRIPTION
DDD（ドメイン駆動設計）の原則に従い、ドメインイベント（BotCreatedEvent, BotConfigChangedEvent, TriggerAddedToBotEvent, TriggerRemovedFromBotEvent, ConversationStoredEvent）を適切に登録および配信するための DomainEventPublisher を導入しました。FirestoreBotRepository および FirestoreConversationRepository 内の save メソッドにおいて、アグリゲートから記録されたイベントを解放してパブリッシュする仕組みを構築し、それに対するテストを完備しました。また、テンプレートから docs/implementation_policy.md を最新として同期しました。

---
*PR created automatically by Jules for task [14438479519211759936](https://jules.google.com/task/14438479519211759936) started by @yananob*