### PR TITLE
不正なスケジュール形式によるタイマー起動エラーの修正

### DIFF
--- a/.github/workflows/add_issues_to_project.yml
+++ b/.github/workflows/add_issues_to_project.yml
@@ -9,7 +9,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.4.0
+      - uses: actions/add-to-project@v2
         with:
           project-url: https://github.com/users/yananob/projects/3
           github-token: ${{ secrets.GH_PAT }}

--- a/src/Domain/Bot/Trigger/TriggerFactory.php
+++ b/src/Domain/Bot/Trigger/TriggerFactory.php
@@ -2,6 +2,8 @@
 
 namespace App\Domain\Bot\Trigger;
 
+use App\Domain\Exception\InvalidTriggerScheduleException;
+
 class TriggerFactory
 {
     /**
@@ -15,9 +17,15 @@ class TriggerFactory
             $date = (string)($data['date'] ?? '');
             $time = (string)($data['time'] ?? '');
             $request = (string)($data['request'] ?? '');
-            $trigger = new TimerTrigger($date, $time, $request);
-            $trigger->setId($id);
-            return $trigger;
+            try {
+                $trigger = new TimerTrigger($date, $time, $request);
+                $trigger->setId($id);
+                return $trigger;
+            } catch (InvalidTriggerScheduleException $e) {
+                // 不正なスケジュール設定を持つトリガーを検出した場合、ログに警告を出力し、nullを返してスキップできるようにする
+                error_log("警告：不正なトリガースケジュール（ID: {$id}）の復元に失敗したため、スキップします。詳細: " . $e->getMessage());
+                return null;
+            }
         }
 
         return null;

--- a/tests/Domain/Bot/Trigger/TriggerFactoryTest.php
+++ b/tests/Domain/Bot/Trigger/TriggerFactoryTest.php
@@ -50,4 +50,21 @@ class TriggerFactoryTest extends TestCase
 
         $this->assertNull($trigger);
     }
+
+    public function testFromArrayWithInvalidSchedule(): void
+    {
+        // 不正なスケジュール設定を含むテストデータ（時刻が「不明」）
+        $id = 'trigger_invalid_schedule';
+        $data = [
+            'event' => 'timer',
+            'date' => 'today',
+            'time' => '不明',
+            'request' => '告白の予定'
+        ];
+
+        // 復元時に例外が発生せず、nullが返ることを検証
+        $trigger = TriggerFactory::fromArray($id, $data);
+
+        $this->assertNull($trigger);
+    }
 }


### PR DESCRIPTION
This change resolves a critical issue where a single malformed or corrupted trigger schedule format (such as '不明') stored in Firestore would throw an `InvalidTriggerScheduleException` during reconstitution, crashing the entire bot loader (`getAllUserBots`) and halting the cron schedule processor for all users.

By robustly catching `InvalidTriggerScheduleException` in `TriggerFactory::fromArray`, printing a Japanese warning log, and returning `null`, the system now gracefully ignores and skips any malformed triggers, allowing the rest of the application to execute successfully.

A test has been added to cover this resilient behavior, and the `.github/workflows/add_issues_to_project.yml` workflow was synchronized with the template directory.

Fixes #180

---
*PR created automatically by Jules for task [13875831213445091525](https://jules.google.com/task/13875831213445091525) started by @yananob*